### PR TITLE
simplify the BQ api

### DIFF
--- a/bigquery_sample.py
+++ b/bigquery_sample.py
@@ -9,15 +9,14 @@ SELECT
   *
 FROM
   `daring-runway-374503.covid_19_search_trends_symptoms_dataset.county_28d_historical`
-LIMIT 1
+LIMIT 10
 """
 
 
 @flow.processor(
-    input_ref=flow.BigQuery(query=flow.BigQuery.Query(
-        _QUERY,
-        temporary_dataset='daring-runway-374503.temporary',
-    )),
+    input_ref=flow.BigQuery(query=_QUERY),
+    output_ref=flow.BigQuery(
+        table_id='daring-runway-374503.ray_example.public'),
 )
 def process(bq_row):
     return bq_row
@@ -26,6 +25,6 @@ def process(bq_row):
 logging.basicConfig(level=logging.INFO)
 start = time.time()
 output = flow.run()
-print('TOTAL SECONDS = ', time.time() - start)
-# TODO something funky going on here with nested data.
+total_time = time.time() - start
 print('OUTPUT: ', output)
+print('TOTAL SECONDS = ', total_time)

--- a/buildflow/api/resources.py
+++ b/buildflow/api/resources.py
@@ -1,6 +1,6 @@
 import dataclasses
 from enum import Enum
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, TypeVar
 
 
 class InputOutput:
@@ -34,19 +34,18 @@ class PubSub(InputOutput):
 @dataclasses.dataclass
 class BigQuery(InputOutput):
 
-    @dataclasses.dataclass
-    class Query:
-        # The query to execute.
-        query: str
-        # Where to temporarily store the results of the query. This is required
-        # so we can better parallelize reading in the data.
-        # This should be of the format project.temporary_dataset
-        temporary_dataset: str
+    # The BigQuery table to read from.
+    # Should be of the format project.dataset.table
+    table_id: str = ''
+    # The query to read data from.
+    query: str = ''
+    # The temporary dataset to store query results in. If unspecified we will
+    # attempt to create one.
+    temporary_dataset: str = ''
+    # The billing project to use for query usage. If unset we will use the
+    # project configured with application default credentials.
+    billing_project: str = ''
 
-    project: str = ''
-    dataset: str = ''
-    table: str = ''
-    query: Optional[Query] = None
     batch_size: int = 1000
     _io_type: str = IOType.BigQuery.value
 


### PR DESCRIPTION
- Removes the requirement for a temporary dataset. If one is not provided we will create one
- Instead of supplying project, dataset, and table_id this is all encapsulated in one var
- Also allow users to pass in an optional billing project.