### PR TITLE
fix: return a single flow results object from flow.run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ def stream_processor(pubsub_message):
   return pubsub_message
 
 # Start the processor(s)
-flow.run(num_replicas=4)
+flow.run().results()
 ```
 
 For a more in depth tutorial see our [walkthroughs](https://www.buildflow.dev/docs/category/walk-throughs).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ def stream_processor(pubsub_message):
   return pubsub_message
 
 # Start the processor(s)
-flow.run().results()
+flow.run().output()
 ```
 
 For a more in depth tutorial see our [walkthroughs](https://www.buildflow.dev/docs/category/walk-throughs).

--- a/buildflow/api/__init__.py
+++ b/buildflow/api/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from .flow import FlowAPI, FlowResults
 from .io import SinkType, SourceType
 from .processor import ProcessorAPI
 from .options import StreamingOptions

--- a/buildflow/api/flow.py
+++ b/buildflow/api/flow.py
@@ -4,6 +4,12 @@ from buildflow.api import options
 from buildflow.api.processor import ProcessorAPI
 
 
+class FlowResults:
+
+    def results(self):
+        pass
+
+
 class FlowAPI:
 
     def processor(input, output: Optional[Any] = None):
@@ -11,5 +17,5 @@ class FlowAPI:
 
     def run(processor_instance: Optional[ProcessorAPI] = None,
             streaming_options: options.StreamingOptions = options.
-            StreamingOptions()):
+            StreamingOptions()) -> FlowResults:
         pass

--- a/buildflow/api/flow.py
+++ b/buildflow/api/flow.py
@@ -6,7 +6,13 @@ from buildflow.api.processor import ProcessorAPI
 
 class FlowResults:
 
-    def results(self):
+    def output(self):
+        """This method will block the flow until completion.
+
+        For batch flows it will return the output of the pipeline.
+
+        For streaming flows it will simply infinitely block.
+        """
         pass
 
 
@@ -15,7 +21,9 @@ class FlowAPI:
     def processor(input, output: Optional[Any] = None):
         pass
 
-    def run(processor_instance: Optional[ProcessorAPI] = None,
-            streaming_options: options.StreamingOptions = options.
-            StreamingOptions()) -> FlowResults:
+    def run(
+        processor_instance: Optional[ProcessorAPI] = None,
+        streaming_options: options.StreamingOptions = options.StreamingOptions(
+        )
+    ) -> FlowResults:
         pass

--- a/buildflow/api/options.py
+++ b/buildflow/api/options.py
@@ -15,7 +15,3 @@ class StreamingOptions:
     # set to false your pipeline will always maintain the same number of
     # replicas as it started with.
     autoscaling: bool = True
-    # If true flow.run() will block as the pipeline executes. If false we will
-    # return a async ref allowing you to block with:
-    #       ray.get(flow.run()['PROC_NAME'])
-    blocking: bool = True

--- a/buildflow/runtime/flow.py
+++ b/buildflow/runtime/flow.py
@@ -37,7 +37,7 @@ class Flow(flow.FlowAPI):
     def run(self,
             processor_instance: Optional[ProcessorAPI] = None,
             streaming_options: options.StreamingOptions = options.
-            StreamingOptions()):
+            StreamingOptions()) -> flow.FlowResults:
         if processor_instance is not None:
             self.runtime.register_processor(processor_instance)
         return self.runtime.run(streaming_options)

--- a/buildflow/runtime/ray_io/empty_io_test.py
+++ b/buildflow/runtime/ray_io/empty_io_test.py
@@ -19,7 +19,7 @@ class EmptyTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        output = self.flow.run().results()
+        output = self.flow.run().output()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output, {'process': {'local': [1, 2, 3]}})
@@ -30,7 +30,7 @@ class EmptyTest(unittest.TestCase):
         def process(elem):
             return [elem, elem]
 
-        output = self.flow.run().results()
+        output = self.flow.run().output()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output,
@@ -48,7 +48,7 @@ class EmptyTest(unittest.TestCase):
             def process(self, num: int):
                 return num
 
-        output = self.flow.run(MyProcessor()).results()
+        output = self.flow.run(MyProcessor()).output()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output, {'MyProcessor': {'local': [1, 2, 3]}})
@@ -63,7 +63,7 @@ class EmptyTest(unittest.TestCase):
         def process2(elem):
             return elem
 
-        output = self.flow.run().results()
+        output = self.flow.run().output()
 
         self.assertEqual(len(output), 2)
         self.assertEqual(output, {

--- a/buildflow/runtime/ray_io/empty_io_test.py
+++ b/buildflow/runtime/ray_io/empty_io_test.py
@@ -19,7 +19,7 @@ class EmptyTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        output = self.flow.run()
+        output = self.flow.run().results()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output, {'process': {'local': [1, 2, 3]}})
@@ -30,7 +30,7 @@ class EmptyTest(unittest.TestCase):
         def process(elem):
             return [elem, elem]
 
-        output = self.flow.run()
+        output = self.flow.run().results()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output,
@@ -48,7 +48,7 @@ class EmptyTest(unittest.TestCase):
             def process(self, num: int):
                 return num
 
-        output = self.flow.run(MyProcessor())
+        output = self.flow.run(MyProcessor()).results()
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output, {'MyProcessor': {'local': [1, 2, 3]}})
@@ -63,7 +63,7 @@ class EmptyTest(unittest.TestCase):
         def process2(elem):
             return elem
 
-        output = self.flow.run()
+        output = self.flow.run().results()
 
         self.assertEqual(len(output), 2)
         self.assertEqual(output, {

--- a/buildflow/runtime/ray_io/file_io_test.py
+++ b/buildflow/runtime/ray_io/file_io_test.py
@@ -34,7 +34,7 @@ class FileIoTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        self.flow.run()
+        self.flow.run().results()
         table = pq.read_table(path)
         self.assertEqual([{'field': 1}, {'field': 2}], table.to_pylist())
 
@@ -55,7 +55,7 @@ class FileIoTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        self.flow.run()
+        self.flow.run().results()
         table = pq.read_table(path)
         self.assertEqual([{'field': 1}, {'field': 2}], table.to_pylist())
 

--- a/buildflow/runtime/ray_io/file_io_test.py
+++ b/buildflow/runtime/ray_io/file_io_test.py
@@ -34,7 +34,7 @@ class FileIoTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        self.flow.run().results()
+        self.flow.run().output()
         table = pq.read_table(path)
         self.assertEqual([{'field': 1}, {'field': 2}], table.to_pylist())
 
@@ -55,7 +55,7 @@ class FileIoTest(unittest.TestCase):
         def process(elem):
             return elem
 
-        self.flow.run().results()
+        self.flow.run().output()
         table = pq.read_table(path)
         self.assertEqual([{'field': 1}, {'field': 2}], table.to_pylist())
 

--- a/buildflow/runtime/ray_io/redis_stream_io_test.py
+++ b/buildflow/runtime/ray_io/redis_stream_io_test.py
@@ -53,7 +53,7 @@ class RedisStreamTest(unittest.TestCase):
             return element
 
         self.flow.run(streaming_options=buildflow.StreamingOptions(
-            autoscaling=False, blocking=False))
+            autoscaling=False))
         time.sleep(10)
 
         data_written = redis_client.xread({'output_stream': 0})
@@ -84,7 +84,7 @@ class RedisStreamTest(unittest.TestCase):
             return [element, element]
 
         self.flow.run(streaming_options=buildflow.StreamingOptions(
-            autoscaling=False, blocking=False))
+            autoscaling=False))
         time.sleep(10)
 
         data_written = redis_client.xread({'output_stream': 0})
@@ -115,7 +115,7 @@ class RedisStreamTest(unittest.TestCase):
             return Output(element['field'])
 
         self.flow.run(streaming_options=buildflow.StreamingOptions(
-            autoscaling=False, blocking=False))
+            autoscaling=False))
         time.sleep(10)
 
         data_written = redis_client.xread({'output_stream': 0})
@@ -146,7 +146,7 @@ class RedisStreamTest(unittest.TestCase):
             return [Output(element['field']), Output(element['field'])]
 
         self.flow.run(streaming_options=buildflow.StreamingOptions(
-            autoscaling=False, blocking=False))
+            autoscaling=False))
         time.sleep(10)
 
         data_written = redis_client.xread({'output_stream': 0})

--- a/buildflow/runtime/runner.py
+++ b/buildflow/runtime/runner.py
@@ -43,7 +43,7 @@ class _StreamingResults(FlowResults):
     def __init__(self, manager: stream_manager.StreamProcessManager) -> None:
         self._manager = manager
 
-    def results(self):
+    def output(self):
         self._manager.block()
 
 
@@ -56,7 +56,7 @@ class _BatchResults(FlowResults):
     def _add_processor_task(self, processor_id: str, tasks):
         self._processor_tasks[processor_id] = tasks
 
-    def results(self):
+    def output(self):
         final_output = {}
         for proc_id, batch_ref in self._processor_tasks.items():
             proc_output = {}

--- a/buildflow/runtime/runner.py
+++ b/buildflow/runtime/runner.py
@@ -12,7 +12,8 @@ import ray
 import requests
 
 from buildflow import utils
-from buildflow.api import ProcessorAPI, SourceType, SinkType, options
+from buildflow.api import (FlowResults, ProcessorAPI, SourceType, SinkType,
+                           options)
 from buildflow.runtime.managers import batch_manager
 from buildflow.runtime.managers import stream_manager
 
@@ -34,6 +35,39 @@ _SESSION_FILE = os.path.join(_SESSION_DIR, 'build_flow_usage.json')
 @dataclasses.dataclass
 class Session:
     id: str
+
+
+@dataclasses.dataclass
+class _StreamingResults(FlowResults):
+
+    def __init__(self, manager: stream_manager.StreamProcessManager) -> None:
+        self._manager = manager
+
+    def results(self):
+        self._manager.block()
+
+
+@dataclasses.dataclass
+class _BatchResults(FlowResults):
+
+    def __init__(self) -> None:
+        self._processor_tasks = {}
+
+    def _add_processor_task(self, processor_id: str, tasks):
+        self._processor_tasks[processor_id] = tasks
+
+    def results(self):
+        final_output = {}
+        for proc_id, batch_ref in self._processor_tasks.items():
+            proc_output = {}
+            output = ray.get(batch_ref)
+            for key, value in output.items():
+                if key in proc_output:
+                    proc_output[key].extend(value)
+                else:
+                    proc_output[key] = value
+            final_output[proc_id] = proc_output
+        return final_output
 
 
 def _load_session():
@@ -106,35 +140,23 @@ class Runtime:
         self._processors = {}
 
     def _run(self, streaming_options: options.StreamingOptions):
-        batch_refs = {}
-        streaming_refs = {}
+        batch_results = _BatchResults()
+        streaming_results = None
         for proc_id, processor_ref in self._processors.items():
             if not processor_ref.source.is_streaming():
                 manager = batch_manager.BatchProcessManager(processor_ref)
-                batch_refs[proc_id] = manager.run()
+                batch_results._add_processor_task(proc_id, manager.run())
             else:
+                assert len(self._processors) == 1
                 manager = stream_manager.StreamProcessManager(
                     processor_ref, streaming_options)
                 manager.run()
-                streaming_refs[proc_id] = manager
+                streaming_results = _StreamingResults(manager)
 
-        final_output = {}
-        for proc_id, streaming_ref in streaming_refs.items():
-            if streaming_options.blocking:
-                streaming_ref.block()
-            else:
-                final_output[proc_id] = streaming_ref
+        if streaming_results is not None:
+            return streaming_results
 
-        for proc_id, batch_ref in batch_refs.items():
-            proc_output = {}
-            output = ray.get(batch_ref)
-            for key, value in output.items():
-                if key in proc_output:
-                    proc_output[key].extend(value)
-                else:
-                    proc_output[key] = value
-            final_output[proc_id] = proc_output
-        return final_output
+        return batch_results
 
     def register_processor(self,
                            processor_instance: ProcessorAPI,
@@ -144,6 +166,20 @@ class Runtime:
         if processor_id in self._processors:
             logging.warning(
                 f'Processor {processor_id} already registered. Overwriting.')
+
+        # For a flow allow 1 streaming processors or N batch processors.
+        # If user is adding a streaming processor ensure their are no other
+        # processors.
+        # If user is adding a batch processor ensure their are no existing
+        # streaming processors.
+        if ((processor_instance.source().is_streaming() and self._processors)
+                or any([
+                    p.source.is_streaming()
+                    for p in self._processors.values()
+                ])):
+            raise ValueError(
+                'Flows containing a streaming processor are only allowed '
+                'to have one processor.')
 
         # NOTE: This is where the source / sink lifecycle methods are executed.
         self._processors[processor_id] = _ProcessorRef(

--- a/buildflow/runtime/runner_test.py
+++ b/buildflow/runtime/runner_test.py
@@ -1,0 +1,69 @@
+import unittest
+
+from buildflow.runtime import runner
+from buildflow.runtime import Processor
+from buildflow.runtime.ray_io import bigquery_io
+from buildflow.runtime.ray_io import pubsub_io
+
+
+class StreamProcessor1(Processor):
+
+    def source(self):
+        return pubsub_io.PubSubSource(subscription='sub')
+
+    def process(self, payload):
+        return payload
+
+
+class StreamProcessor2(Processor):
+
+    def source(self):
+        return pubsub_io.PubSubSource(subscription='sub')
+
+    def process(self, payload):
+        return payload
+
+
+class BatchProcessor1(Processor):
+
+    def source(self):
+        return bigquery_io.BigQuerySource(table_id='a.b.c')
+
+    def process(self, payload):
+        return payload
+
+
+class BatchProcessor2(Processor):
+
+    def source(self):
+        return bigquery_io.BigQuerySource(table_id='a.b.c')
+
+    def process(self, payload):
+        return payload
+
+
+_ERROR_TEXT = 'Flows containing a streaming processor are only allowed to have one processor.'  # noqa: E501
+
+
+class RunnerTest(unittest.TestCase):
+
+    def test_add_multiple_streaming(self):
+        runtime = runner.Runtime()
+        runtime.register_processor(StreamProcessor1())
+        with self.assertRaisesRegex(ValueError, _ERROR_TEXT):
+            runtime.register_processor(StreamProcessor2())
+
+    def test_add_multiple_batch(self):
+        runtime = runner.Runtime()
+        runtime.register_processor(BatchProcessor1())
+        runtime.register_processor(BatchProcessor2())
+
+    def test_add_batch_and_streaming(self):
+        runtime = runner.Runtime()
+        runtime.register_processor(BatchProcessor1())
+        with self.assertRaisesRegex(ValueError, _ERROR_TEXT):
+            runtime.register_processor(StreamProcessor2())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/buildflow/samples/bigquery_sample.py
+++ b/buildflow/samples/bigquery_sample.py
@@ -37,7 +37,6 @@ def process_query_result(dataset: ray.data.Dataset):
 
 
 logging.basicConfig(level=logging.INFO)
-# NOTE: You can increase the number of replicas to load the dataset faster.
-output = flow.run(num_replicas=1)
+output = flow.run().results()
 
 # NOTE: You can (optionally) do something with the processed output.

--- a/buildflow/samples/bigquery_sample.py
+++ b/buildflow/samples/bigquery_sample.py
@@ -37,6 +37,6 @@ def process_query_result(dataset: ray.data.Dataset):
 
 
 logging.basicConfig(level=logging.INFO)
-output = flow.run().results()
+output = flow.run().output()
 
 # NOTE: You can (optionally) do something with the processed output.

--- a/buildflow/samples/class_sample.py
+++ b/buildflow/samples/class_sample.py
@@ -43,6 +43,4 @@ class MyProcessor(buildflow.Processor):
         return message_data
 
 
-# NOTE: You can increase the number of replicas to process the messages faster.
-# 1 replica == 1 process. Each replica is multithreaded by default.
-flow.run(MyProcessor(), num_replicas=1)
+flow.run(MyProcessor()).results()

--- a/buildflow/samples/class_sample.py
+++ b/buildflow/samples/class_sample.py
@@ -43,4 +43,4 @@ class MyProcessor(buildflow.Processor):
         return message_data
 
 
-flow.run(MyProcessor()).results()
+flow.run(MyProcessor()).output()

--- a/buildflow/samples/decorator_sample.py
+++ b/buildflow/samples/decorator_sample.py
@@ -25,4 +25,4 @@ def process(taxi_info):
     return taxi_info
 
 
-flow.run().results()
+flow.run().output()

--- a/buildflow/samples/decorator_sample.py
+++ b/buildflow/samples/decorator_sample.py
@@ -25,5 +25,4 @@ def process(taxi_info):
     return taxi_info
 
 
-# NOTE: You can increase the number of replicas to process the messages faster.
-flow.run(num_replicas=1)
+flow.run().results()

--- a/buildflow/samples/local_pubsub_walkthrough.py
+++ b/buildflow/samples/local_pubsub_walkthrough.py
@@ -43,4 +43,4 @@ def process(element: Dict[str, Any]):
 
 
 # Run our flow.
-flow.run()
+flow.run().results()

--- a/buildflow/samples/local_pubsub_walkthrough.py
+++ b/buildflow/samples/local_pubsub_walkthrough.py
@@ -43,4 +43,4 @@ def process(element: Dict[str, Any]):
 
 
 # Run our flow.
-flow.run().results()
+flow.run().output()

--- a/buildflow/samples/notebook_sample.ipynb
+++ b/buildflow/samples/notebook_sample.ipynb
@@ -39,7 +39,7 @@
         "    return table\n",
         "# NOTE: It is best to keep flow.run and your processor definition in the same\n",
         "# code block.\n",
-        "output = flow.run(num_replicas=1)"
+        "output = flow.run().results()"
       ]
     },
     {

--- a/buildflow/samples/notebook_sample.ipynb
+++ b/buildflow/samples/notebook_sample.ipynb
@@ -39,7 +39,7 @@
         "    return table\n",
         "# NOTE: It is best to keep flow.run and your processor definition in the same\n",
         "# code block.\n",
-        "output = flow.run().results()"
+        "output = flow.run().output()"
       ]
     },
     {

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -53,4 +53,4 @@ def process(element: Dict[str, Any]) -> TaxiOutput:
 
 
 # Run our flow.
-flow.run().results()
+flow.run().output()

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -53,4 +53,4 @@ def process(element: Dict[str, Any]) -> TaxiOutput:
 
 
 # Run our flow.
-flow.run(streaming_options=buildflow.StreamingOptions())
+flow.run().results()

--- a/integration_tests/pubsub_to_local_parquet/pubsub_main.py
+++ b/integration_tests/pubsub_to_local_parquet/pubsub_main.py
@@ -33,4 +33,4 @@ class MyProcessor(buildflow.Processor):
         return Output(payload['val'] + 1)
 
 
-flow.run(MyProcessor()).results()
+flow.run(MyProcessor()).output()

--- a/integration_tests/pubsub_to_local_parquet/pubsub_main.py
+++ b/integration_tests/pubsub_to_local_parquet/pubsub_main.py
@@ -33,8 +33,4 @@ class MyProcessor(buildflow.Processor):
         return Output(payload['val'] + 1)
 
 
-ref = flow.run(MyProcessor(),
-               streaming_options=buildflow.StreamingOptions(
-                   blocking=False))
-
-ref['MyProcessor'].block()
+flow.run(MyProcessor()).results()

--- a/integration_tests/pubsub_to_pubsub/pubsub_main.py
+++ b/integration_tests/pubsub_to_pubsub/pubsub_main.py
@@ -27,4 +27,4 @@ class MyProcessor(buildflow.Processor):
         return Output(payload['val'] + 1)
 
 
-flow.run(MyProcessor()).results()
+flow.run(MyProcessor()).output()

--- a/integration_tests/pubsub_to_pubsub/pubsub_main.py
+++ b/integration_tests/pubsub_to_pubsub/pubsub_main.py
@@ -27,8 +27,4 @@ class MyProcessor(buildflow.Processor):
         return Output(payload['val'] + 1)
 
 
-ref = flow.run(MyProcessor(),
-               streaming_options=buildflow.StreamingOptions(
-                   blocking=False))
-
-ref['MyProcessor'].block()
+flow.run(MyProcessor()).results()

--- a/integration_tests/pubsub_to_pubsub_multi_output/pubsub_main.py
+++ b/integration_tests/pubsub_to_pubsub_multi_output/pubsub_main.py
@@ -21,8 +21,4 @@ class MyProcessor(buildflow.Processor):
         return [payload, payload]
 
 
-ref = flow.run(MyProcessor(),
-               streaming_options=buildflow.StreamingOptions(
-                   blocking=False))
-
-ref['MyProcessor'].block()
+flow.run(MyProcessor()).results()

--- a/integration_tests/pubsub_to_pubsub_multi_output/pubsub_main.py
+++ b/integration_tests/pubsub_to_pubsub_multi_output/pubsub_main.py
@@ -21,4 +21,4 @@ class MyProcessor(buildflow.Processor):
         return [payload, payload]
 
 
-flow.run(MyProcessor()).results()
+flow.run(MyProcessor()).output()


### PR DESCRIPTION
This makes it easier for folks to flow with the `.results()` method if they want to.

It also adds some more constraints on what kind of processors can be used together. Essentially the rule is it either needs to be all batch or all streaming, and only one streaming processor is allowed. We could maybe loosen this rule if we need to, but for right now it helps limit some weird edge cases with running them together.