### PR TITLE
fix: improvements to the autoscaller

### DIFF
--- a/.github/workflows/gcp_integration.yaml
+++ b/.github/workflows/gcp_integration.yaml
@@ -26,8 +26,9 @@ jobs:
       - name: Setup GCP Auth
         uses: 'google-github-actions/auth@v1'
         with:
-          workload_identity_provider: ${{ secrets.WORKFLOW_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # NOTE: We use a key file here because changing the quota project
+          # doesn't work with WIF.
+          credentials_json: ${{ secrets.GCP_SA_JSON_KEY }}
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
@@ -62,7 +63,6 @@ jobs:
           # NOTE: We use a key file here because pyarrow doesn't support
           # authenticating with workflow identity federation.
           credentials_json: ${{ secrets.GCP_SA_JSON_KEY }}
-
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
 
@@ -95,8 +95,9 @@ jobs:
       - name: Setup GCP Auth
         uses: 'google-github-actions/auth@v1'
         with:
-          workload_identity_provider: ${{ secrets.WORKFLOW_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # NOTE: We use a key file here because changing the quota project
+          # doesn't work with WIF.
+          credentials_json: ${{ secrets.GCP_SA_JSON_KEY }}
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'

--- a/buildflow/api/io.py
+++ b/buildflow/api/io.py
@@ -6,7 +6,11 @@ class _BaseIO:
 
     @classmethod
     def num_cpus(cls) -> float:
-        return .25
+        # IO options don't need much CPU pretty much just need enough keep it
+        # scheduled.
+        # TODO: we should probably make this configurable though to help
+        # prevent OOMs.
+        return .01
 
 
 class Source(_BaseIO):

--- a/buildflow/api/io.py
+++ b/buildflow/api/io.py
@@ -10,7 +10,7 @@ class _BaseIO:
         # scheduled.
         # TODO: we should probably make this configurable though to help
         # prevent OOMs.
-        return .01
+        return .1
 
 
 class Source(_BaseIO):

--- a/buildflow/api/processor.py
+++ b/buildflow/api/processor.py
@@ -28,3 +28,6 @@ class ProcessorAPI:
     # Returns the arg spec of the process method.
     def processor_arg_spec(self):
         raise NotImplementedError('process not implemented')
+
+    def num_cpus(self) -> float:
+        return .5

--- a/buildflow/runtime/flow.py
+++ b/buildflow/runtime/flow.py
@@ -31,8 +31,11 @@ class Flow(flow.FlowAPI):
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def processor(self, source: SourceType, sink: Optional[SinkType] = None):
-        return processor(self.runtime, source, sink)
+    def processor(self,
+                  source: SourceType,
+                  sink: Optional[SinkType] = None,
+                  num_cpus: float = .5):
+        return processor(self.runtime, source, sink, num_cpus)
 
     def run(
         self,

--- a/buildflow/runtime/managers/auto_scaler.py
+++ b/buildflow/runtime/managers/auto_scaler.py
@@ -24,10 +24,7 @@ _TARGET_UTILIZATION = .5
 
 
 def max_replicas_for_cluster(cpu_per_replica: float):
-    print('DO NOT SUBMIT: cpu per replica: ', cpu_per_replica)
     num_cpus = ray.cluster_resources()['CPU']
-
-    print('DO NOT SUBMIT: max replicas: ', int(num_cpus / cpu_per_replica))
 
     return int(num_cpus / cpu_per_replica)
 

--- a/buildflow/runtime/managers/auto_scaler_test.py
+++ b/buildflow/runtime/managers/auto_scaler_test.py
@@ -31,7 +31,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 autoscaling_options=options.StreamingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
@@ -60,7 +60,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 autoscaling_options=options.StreamingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
@@ -85,7 +85,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 # Max replicas will cap recommendation. Even though we need 8
                 # to burn down the backlog we won't scale beyond max_replicas.
                 autoscaling_options=options.StreamingOptions(max_replicas=5),
@@ -106,8 +106,7 @@ class AutoScalerTest(unittest.TestCase):
         # (100_000 / 100).
         # However this will be limited by the number of CPUs on our cluster.
         # We have 32 CPUs in our mock cluster, so we will only scale to:
-        #   32 / .25 * .66 = 84
-        #   num_cpus / source_cpus / REPLICA_CPU_RATION
+        #   32 / .5 = 64
         events_processed_per_replica = [100] * 3
         non_empty_ratio_per_replica = [1] * 3
 
@@ -118,18 +117,18 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.5,
                 autoscaling_options=options.StreamingOptions(max_replicas=85),
             )
             self.assertEqual(len(self._caplog.records), 2)
             expected_log = (
                 'reached the max allowed replicas for your cluster '
-                '84. We will add more as your cluster scales up.')
+                '64. We will add more as your cluster scales up.')
             self.assertEqual(self._caplog.records[0].message, expected_log)
-            expected_log = 'resizing from 3 replicas to 84 replicas'
+            expected_log = 'resizing from 3 replicas to 64 replicas'
             self.assertEqual(self._caplog.records[1].message, expected_log)
 
-            self.assertEqual(84, rec_replicas)
+            self.assertEqual(64, rec_replicas)
 
     def test_scale_up_to_max_cpu_replicas_equals_max_options(
             self, resources_mock):
@@ -152,7 +151,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 autoscaling_options=options.StreamingOptions(max_replicas=84),
             )
             self.assertEqual(len(self._caplog.records), 2)
@@ -182,7 +181,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 autoscaling_options=options.StreamingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
@@ -210,7 +209,7 @@ class AutoScalerTest(unittest.TestCase):
                 events_processed_per_replica=events_processed_per_replica,
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=120,
-                source_cpus=.25,
+                cpus_per_replica=.1,
                 # Don't scale below 18 replicas.
                 autoscaling_options=options.StreamingOptions(min_replicas=18),
             )

--- a/buildflow/runtime/managers/batch_manager.py
+++ b/buildflow/runtime/managers/batch_manager.py
@@ -11,11 +11,11 @@ class BatchProcessManager:
         key = str(self.processor_ref.sink)
         if isinstance(self.processor_ref.sink, empty_io.EmptySink):
             key = 'local'
-        processor_actor = processors.ProcessActor.remote(
-            self.processor_ref.get_processor_replica())
+        processor_actor = processors.ProcessActor.options(
+            num_cpues=self.processor_ref.processor_instance.num_cpus()).remote(
+                self.processor_ref.get_processor_replica())
         sink_actor = self.processor_ref.sink.actor(
-            processor_actor,
-            self.processor_ref.source.is_streaming())
+            processor_actor, self.processor_ref.source.is_streaming())
 
         source_actor = self.processor_ref.source.actor({key: sink_actor})
         return source_actor.run.remote()

--- a/buildflow/runtime/managers/batch_manager.py
+++ b/buildflow/runtime/managers/batch_manager.py
@@ -14,7 +14,7 @@ class BatchProcessManager:
         processor_actor = processors.ProcessActor.remote(
             self.processor_ref.get_processor_replica())
         sink_actor = self.processor_ref.sink.actor(
-            processor_actor.process_batch.remote,
+            processor_actor,
             self.processor_ref.source.is_streaming())
 
         source_actor = self.processor_ref.source.actor({key: sink_actor})

--- a/buildflow/runtime/managers/batch_manager.py
+++ b/buildflow/runtime/managers/batch_manager.py
@@ -12,7 +12,7 @@ class BatchProcessManager:
         if isinstance(self.processor_ref.sink, empty_io.EmptySink):
             key = 'local'
         processor_actor = processors.ProcessActor.options(
-            num_cpues=self.processor_ref.processor_instance.num_cpus()).remote(
+            num_cpus=self.processor_ref.processor_instance.num_cpus()).remote(
                 self.processor_ref.get_processor_replica())
         sink_actor = self.processor_ref.sink.actor(
             processor_actor, self.processor_ref.source.is_streaming())

--- a/buildflow/runtime/managers/processors.py
+++ b/buildflow/runtime/managers/processors.py
@@ -20,7 +20,7 @@ class ProcessorRef:
 
 
 # TODO(#113): make this configurable by the user
-@ray.remote(num_cpus=.5)
+@ray.remote
 class ProcessActor(object):
 
     def __init__(self, processor_instance: ProcessorAPI):

--- a/buildflow/runtime/managers/processors.py
+++ b/buildflow/runtime/managers/processors.py
@@ -45,5 +45,5 @@ class ProcessActor(object):
         for call in calls:
             to_ret.append(self.process(call))
         self.process_time_gauge.set(
-            round(((time.time() - start_time) * 1000) / len(to_ret)))
+            (time.time() - start_time) * 1000 / len(to_ret))
         return to_ret

--- a/buildflow/runtime/managers/processors.py
+++ b/buildflow/runtime/managers/processors.py
@@ -39,7 +39,7 @@ class ProcessActor(object):
     def process(self, *args, **kwargs):
         return self._processor._process(*args, **kwargs)
 
-    def process_batch(self, calls: Iterable):
+    async def process_batch(self, calls: Iterable):
         start_time = time.time()
         to_ret = []
         for call in calls:

--- a/buildflow/runtime/managers/stream_manager.py
+++ b/buildflow/runtime/managers/stream_manager.py
@@ -208,7 +208,9 @@ class _StreamManagerActor:
                     events_processed.append(metric.num_events)
                     non_empty_ratios.append(metric.non_empty_response_ratio)
 
-                self.num_events_counter.inc(sum(events_processed))
+                total_events_process = sum(events_processed)
+                if total_events_process > 0:
+                    self.num_events_counter.inc(total_events_process)
                 self._replicas = new_replicas
                 num_replicas = len(self._replicas)
                 if self.options.autoscaling:

--- a/buildflow/runtime/managers/stream_manager.py
+++ b/buildflow/runtime/managers/stream_manager.py
@@ -176,12 +176,8 @@ class _StreamManagerActor:
             self._add_replica()
         last_check_in = None
         while self.running:
-            # Add a brief wait here to ensure we can check for shutdown events.
-            # and free up the event loop
+            # Sleep until it's time for the next check in.
             await asyncio.sleep(_REPLICA_CHECK_IN)
-            if not self.options.autoscaling:
-                # no autoscaling so just let the replicas run.
-                continue
             now = time.time()
             if last_check_in is None:
                 last_check_in = now

--- a/buildflow/runtime/processor.py
+++ b/buildflow/runtime/processor.py
@@ -28,7 +28,8 @@ class Processor(ProcessorAPI):
 
 def processor(runtime: Runtime,
               source: SourceType,
-              sink: Optional[SinkType] = None):
+              sink: Optional[SinkType] = None,
+              num_cpus: float = .5):
 
     if sink is None:
         sink = empty_io.EmptySink()
@@ -53,7 +54,8 @@ def processor(runtime: Runtime,
                 lambda self: inspect.getfullargspec(original_function),
                 '_process':
                 lambda self, payload: original_function(self.source().
-                                                        preprocess(payload))
+                                                        preprocess(payload)),
+                'num_cpus': lambda self: num_cpus
             })
         processor_instance = _AdHocProcessor()
         runtime.register_processor(processor_instance,

--- a/buildflow/runtime/ray_io/base.py
+++ b/buildflow/runtime/ray_io/base.py
@@ -6,7 +6,6 @@ import os
 from typing import Any, Callable, Dict, Iterable, Union
 
 import ray
-from ray.util.metrics import Gauge
 
 from buildflow.runtime import tracer as t
 from buildflow import utils
@@ -136,20 +135,12 @@ class StreamingRaySource(RaySource):
         self._requests = 0
         self._secs = 0
         self._replica_id = utils.uuid()
-        self.throughput_gauge = Gauge(
-            "throughput",
-            description="Current throughput of the actor. Goes up and down.",
-            tag_keys=("actor_name", ),
-        )
-        self.throughput_gauge.set_default_tags(
-            {"actor_name": self.__class__.__name__})
 
     def update_metrics(self, num_events: int):
         self._num_events += num_events
         self._requests += 1
         if not num_events:
             self._empty_responses += 1
-        self.throughput_gauge.set(num_events)
 
     def metrics(self) -> float:
         """Returns the utilization of the source since this was last called.

--- a/buildflow/runtime/ray_io/base.py
+++ b/buildflow/runtime/ray_io/base.py
@@ -144,13 +144,12 @@ class StreamingRaySource(RaySource):
         self.throughput_gauge.set_default_tags(
             {"actor_name": self.__class__.__name__})
 
-    def update_metrics(self, num_events: int, execution_time_secs: float):
+    def update_metrics(self, num_events: int):
         self._num_events += num_events
         self._requests += 1
         if not num_events:
             self._empty_responses += 1
-        self._events_per_second = num_events / execution_time_secs
-        self.throughput_gauge.set(round(self._events_per_second, 2))
+        self.throughput_gauge.set(num_events)
 
     def metrics(self) -> float:
         """Returns the utilization of the source since this was last called.

--- a/buildflow/runtime/ray_io/base.py
+++ b/buildflow/runtime/ray_io/base.py
@@ -58,10 +58,10 @@ class RaySink:
         if isinstance(elements, ray.data.Dataset):
             # If the elements are a ray dataset, we need to wrap in a list
             # since the remote function expects a list of elements.
-            temp = await self.remote_fn([elements])
+            temp = await self.remote_fn.process_batch.remote([elements])
             results = temp[0]
         else:
-            temp_results = await self.remote_fn(elements)
+            temp_results = await self.remote_fn.process_batch.remote(elements)
             results = []
             for result in temp_results:
                 if isinstance(result, (tuple, list)):

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -144,7 +144,6 @@ class BigQuerySink(io.Sink):
         if not self.billing_project:
             split_table = self.table_id.split('.')
             self.billing_project = split_table[0]
-        print('DO NOT SUBMIT: ', self.billing_project)
 
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         client = clients.get_bigquery_client(self.billing_project)

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -145,10 +145,6 @@ class BigQuerySink(io.Sink):
             split_table = self.table_id.split('.')
             self.billing_project = split_table[0]
 
-    @classmethod
-    def num_cpus(cls) -> float:
-        return .5
-
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         client = clients.get_bigquery_client(self.billing_project)
         schema = None

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -144,6 +144,7 @@ class BigQuerySink(io.Sink):
         if not self.billing_project:
             split_table = self.table_id.split('.')
             self.billing_project = split_table[0]
+        print('DO NOT SUBMIT: ', self.billing_project)
 
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         client = clients.get_bigquery_client(self.billing_project)

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -227,7 +227,7 @@ class BigQuerySourceActor(base.RaySource):
     async def run(self):
         if len(self.bq_read_session_stream_ids) == 1:
             stream = self.bq_read_session_stream_ids[0]
-            response = self.get_bigquery_storage_client(
+            response = clients.get_bigquery_storage_client(
                 self.billing_project).read_rows(stream)
             arrow_subtables = [response.to_arrow()]
         else:

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -210,7 +210,7 @@ def _load_arrow_table_from_stream(stream: str, project: str) -> pa.Table:
     return response.to_arrow()
 
 
-@ray.remote
+@ray.remote(num_cpus=BigQuerySource.num_cpus())
 class BigQuerySourceActor(base.RaySource):
 
     def __init__(
@@ -298,8 +298,7 @@ def ray_dataset_load_job(dataset: ray.data.Dataset, bigquery_table_id: str,
                                  bigquery.SourceFormat.PARQUET, project)
 
 
-# TODO: put more though into this resource requirement
-@ray.remote(num_cpus=.25)
+@ray.remote(num_cpus=BigQuerySink.num_cpus())
 class BigQuerySinkActor(base.RaySink):
 
     # TODO: should make this configure able.

--- a/buildflow/runtime/ray_io/bigquery_io.py
+++ b/buildflow/runtime/ray_io/bigquery_io.py
@@ -145,6 +145,10 @@ class BigQuerySink(io.Sink):
             split_table = self.table_id.split('.')
             self.billing_project = split_table[0]
 
+    @classmethod
+    def num_cpus(cls) -> float:
+        return .5
+
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         client = clients.get_bigquery_client(self.billing_project)
         schema = None

--- a/buildflow/runtime/ray_io/duckdb_io.py
+++ b/buildflow/runtime/ray_io/duckdb_io.py
@@ -34,7 +34,7 @@ class DuckDBSink(io.Sink):
         return DuckDBSinkActor.remote(remote_fn, self)
 
 
-@ray.remote
+@ray.remote(num_cpus=DuckDBSource.num_cpus())
 class DuckDBSourceActor(base.RaySource):
 
     def __init__(
@@ -66,7 +66,7 @@ class DuckDBSourceActor(base.RaySource):
 _MAX_CONNECT_TRIES = 20
 
 
-@ray.remote
+@ray.remote(num_cpus=DuckDBSource.num_cpus())
 class DuckDBSinkActor(base.RaySink):
 
     def __init__(

--- a/buildflow/runtime/ray_io/empty_io.py
+++ b/buildflow/runtime/ray_io/empty_io.py
@@ -25,7 +25,7 @@ class EmptySink(io.Sink):
         return EmptySinkActor.remote(remote_fn)
 
 
-@ray.remote
+@ray.remote(num_cpus=EmptySource.num_cpus())
 class EmptySourceActor(base.RaySource):
 
     def __init__(
@@ -45,7 +45,7 @@ class EmptySourceActor(base.RaySource):
         return await self._send_batch_to_sinks_and_await(self.inputs)
 
 
-@ray.remote
+@ray.remote(num_cpus=EmptySink.num_cpus())
 class EmptySinkActor(base.RaySink):
 
     async def _write(

--- a/buildflow/runtime/ray_io/file_io.py
+++ b/buildflow/runtime/ray_io/file_io.py
@@ -36,7 +36,7 @@ class FileSink(io.Sink):
         return FileSinkActor.remote(remote_fn, self)
 
 
-@ray.remote
+@ray.remote(num_cpus=FileSink.num_cpus())
 class FileSinkActor(base.RaySink):
 
     def __init__(self, remote_fn, file_sink: FileSink) -> None:

--- a/buildflow/runtime/ray_io/gcp/clients.py
+++ b/buildflow/runtime/ray_io/gcp/clients.py
@@ -17,12 +17,12 @@ def _get_gcp_creds(quota_project_id: str) -> Credentials:
 
 def get_storage_client(project: str = None) -> storage.Client:
     creds = _get_gcp_creds(project)
-    return storage.Client(project=project, credentials=creds)
+    return storage.Client(credentials=creds)
 
 
 def get_bigquery_client(project: str = None) -> bigquery.Client:
     creds = _get_gcp_creds(project)
-    return bigquery.Client(project=project, credentials=creds)
+    return bigquery.Client(credentials=creds)
 
 
 def get_bigquery_storage_client(

--- a/buildflow/runtime/ray_io/gcp/clients.py
+++ b/buildflow/runtime/ray_io/gcp/clients.py
@@ -28,12 +28,12 @@ def get_bigquery_client(project: str = None) -> bigquery.Client:
 def get_bigquery_storage_client(
         project: str = None) -> bigquery_storage_v1.BigQueryReadClient:
     creds = _get_gcp_creds(project)
-    return bigquery_storage_v1.BigQueryReadClient(creds)
+    return bigquery_storage_v1.BigQueryReadClient(credentials=creds)
 
 
 def get_metrics_client(project: str):
     creds = _get_gcp_creds(project)
-    return monitoring_v3.MetricServiceClient(creds)
+    return monitoring_v3.MetricServiceClient(credentials=creds)
 
 
 def get_subscriber_client(project: str):

--- a/buildflow/runtime/ray_io/gcp/clients.py
+++ b/buildflow/runtime/ray_io/gcp/clients.py
@@ -17,12 +17,12 @@ def _get_gcp_creds(quota_project_id: str) -> Credentials:
 
 def get_storage_client(project: str = None) -> storage.Client:
     creds = _get_gcp_creds(project)
-    return storage.Client(credentials=creds)
+    return storage.Client(credentials=creds, project=project)
 
 
 def get_bigquery_client(project: str = None) -> bigquery.Client:
     creds = _get_gcp_creds(project)
-    return bigquery.Client(credentials=creds)
+    return bigquery.Client(credentials=creds, project=project)
 
 
 def get_bigquery_storage_client(

--- a/buildflow/runtime/ray_io/gcp/clients.py
+++ b/buildflow/runtime/ray_io/gcp/clients.py
@@ -36,7 +36,7 @@ def get_metrics_client(project: str):
     return monitoring_v3.MetricServiceClient(credentials=creds)
 
 
-def get_subscriber_client(project: str):
+def get_async_subscriber_client(project: str):
     creds = _get_gcp_creds(project)
     return SubscriberAsyncClient(credentials=creds)
 
@@ -44,3 +44,8 @@ def get_subscriber_client(project: str):
 def get_publisher_client(project: str):
     creds = _get_gcp_creds(project)
     return pubsub.PublisherClient(credentials=creds)
+
+
+def get_subscriber_client(project: str):
+    creds = _get_gcp_creds(project)
+    return pubsub.SubscriberClient(credentials=creds)

--- a/buildflow/runtime/ray_io/gcs_io.py
+++ b/buildflow/runtime/ray_io/gcs_io.py
@@ -98,8 +98,9 @@ class GCSFileNotifications(io.StreamingSource):
                 f'serviceAccount:service-{bucket.project_number}@gs-project-accounts.iam.gserviceaccount.com'  # noqa: E501
             )
             pubsub_utils.maybe_create_subscription(
-                self.pubsub_subscription,
-                self.pubsub_topic,
+                pubsub_subscription=self.pubsub_subscription,
+                pubsub_topic=self.pubsub_topic,
+                billing_project=self.billing_project,
                 publisher_members=[gcs_notify_sa])
         if self._managed_publisher:
             notification_found = False

--- a/buildflow/runtime/ray_io/pubsub_io.py
+++ b/buildflow/runtime/ray_io/pubsub_io.py
@@ -1,13 +1,11 @@
 """IO connectors for Pub/Sub and Ray."""
 
-import asyncio
 import dataclasses
 import datetime
 from google.cloud.monitoring_v3 import query
 import inspect
 import logging
 import json
-import time
 from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 import ray
@@ -178,13 +176,10 @@ class PubSubSourceActor(base.StreamingRaySource):
                     # This nacks the messages. See:
                     # https://github.com/googleapis/python-pubsub/pull/123/files
                     ack_deadline_seconds = 0
-                    pubsub_client.modify_ack_deadline(
+                    await pubsub_client.modify_ack_deadline(
                         subscription=self.subscription,
                         ack_ids=ack_ids,
                         ack_deadline_seconds=ack_deadline_seconds)
-            else:
-                # This happens when we didn't get any messages.
-                await asyncio.sleep(3)
             # For pub/sub we determine the utilization based on the number of
             # messages received versus how many we received.
             self.update_metrics(len(payloads))

--- a/buildflow/runtime/ray_io/pubsub_io.py
+++ b/buildflow/runtime/ray_io/pubsub_io.py
@@ -191,8 +191,7 @@ class PubSubSourceActor(base.StreamingRaySource):
         return True
 
 
-# TODO: put more though into this resource requirement
-@ray.remote(num_cpus=.25)
+@ray.remote(num_cpus=PubSubSink.num_cpus())
 class PubSubSinkActor(base.RaySink):
 
     def __init__(

--- a/buildflow/runtime/ray_io/pubsub_io.py
+++ b/buildflow/runtime/ray_io/pubsub_io.py
@@ -139,7 +139,6 @@ class PubSubSourceActor(base.StreamingRaySource):
         pubsub_client = clients.get_async_subscriber_client(
             self.billing_project)
         while self.running:
-            start_time = time.time()
             ack_ids = []
             payloads = []
             try:
@@ -188,7 +187,7 @@ class PubSubSourceActor(base.StreamingRaySource):
                 await asyncio.sleep(3)
             # For pub/sub we determine the utilization based on the number of
             # messages received versus how many we received.
-            self.update_metrics(len(payloads), time.time() - start_time)
+            self.update_metrics(len(payloads))
 
     def shutdown(self):
         self.running = False

--- a/buildflow/runtime/ray_io/pubsub_io_test.py
+++ b/buildflow/runtime/ray_io/pubsub_io_test.py
@@ -8,13 +8,16 @@ from buildflow.runtime.ray_io import pubsub_io as io
 
 class PubsubIOTest(unittest.TestCase):
 
+    @mock.patch('google.auth.default')
     @mock.patch('google.cloud.pubsub.PublisherClient')
     @mock.patch('google.cloud.pubsub.SubscriberClient')
     def test_pubsub_source_setup_create_sub_and_topic(
         self,
         sub_client_mock: mock.MagicMock,
         pub_client_mock: mock.MagicMock,
+        auth_mock: mock.MagicMock,
     ):
+        auth_mock.return_value = (None, None)
         pub_mock = pub_client_mock.return_value
         sub_mock = sub_client_mock.return_value
 
@@ -33,13 +36,16 @@ class PubsubIOTest(unittest.TestCase):
             topic='projects/project/topics/pubsub-topic',
             ack_deadline_seconds=600)
 
+    @mock.patch('google.auth.default')
     @mock.patch('google.cloud.pubsub.PublisherClient')
     @mock.patch('google.cloud.pubsub.SubscriberClient')
     def test_pubsub_source_setup_create_only_sub(
         self,
         sub_client_mock: mock.MagicMock,
         pub_client_mock: mock.MagicMock,
+        auth_mock: mock.MagicMock,
     ):
+        auth_mock.return_value = (None, None)
         pub_mock = pub_client_mock.return_value
         sub_mock = sub_client_mock.return_value
         sub_mock.get_subscription.side_effect = exceptions.NotFound('unused')
@@ -55,13 +61,16 @@ class PubsubIOTest(unittest.TestCase):
             topic='projects/project/topics/pubsub-topic',
             ack_deadline_seconds=600)
 
+    @mock.patch('google.auth.default')
     @mock.patch('google.cloud.pubsub.PublisherClient')
     @mock.patch('google.cloud.pubsub.SubscriberClient')
     def test_pubsub_source_setup_create_none_created(
         self,
         sub_client_mock: mock.MagicMock,
         pub_client_mock: mock.MagicMock,
+        auth_mock: mock.MagicMock,
     ):
+        auth_mock.return_value = (None, None)
         pub_mock = pub_client_mock.return_value
         sub_mock = sub_client_mock.return_value
 
@@ -73,11 +82,14 @@ class PubsubIOTest(unittest.TestCase):
         pub_mock.create_topic.assert_not_called()
         sub_mock.create_subscription.assert_not_called()
 
+    @mock.patch('google.auth.default')
     @mock.patch('google.cloud.pubsub.SubscriberClient')
     def test_pubsub__source_setup_create_sub_no_topic(
         self,
         sub_client_mock: mock.MagicMock,
+        auth_mock: mock.MagicMock,
     ):
+        auth_mock.return_value = (None, None)
         sub_mock = sub_client_mock.return_value
         sub_mock.get_subscription.side_effect = exceptions.NotFound('unused')
 
@@ -90,11 +102,14 @@ class PubsubIOTest(unittest.TestCase):
         ):
             pubsub_io.setup()
 
+    @mock.patch('google.auth.default')
     @mock.patch('google.cloud.pubsub.PublisherClient')
     def test_pubsub_setup_create_topic(
         self,
         pub_client_mock: mock.MagicMock,
+        auth_mock: mock.MagicMock,
     ):
+        auth_mock.return_value = (None, None)
         pub_mock = pub_client_mock.return_value
 
         pub_mock.get_topic.side_effect = exceptions.NotFound('unused')

--- a/buildflow/runtime/ray_io/redis_stream_io.py
+++ b/buildflow/runtime/ray_io/redis_stream_io.py
@@ -41,7 +41,7 @@ class RedisStreamSink(io.Sink):
         return RedisStreamOutput.remote(remote_fn, self)
 
 
-@ray.remote
+@ray.remote(num_cpus=RedisStreamSource.num_cpus())
 class RedisStreamInput(base.StreamingRaySource):
 
     def __init__(
@@ -99,7 +99,7 @@ class RedisStreamInput(base.StreamingRaySource):
         return True
 
 
-@ray.remote
+@ray.remote(num_cpus=RedisStreamSink.num_cpus())
 class RedisStreamOutput(base.RaySink):
 
     def __init__(

--- a/buildflow/runtime/ray_io/sqs_io.py
+++ b/buildflow/runtime/ray_io/sqs_io.py
@@ -1,7 +1,6 @@
 import asyncio
 from dataclasses import dataclass
 import logging
-import time
 from typing import Any, Dict, Optional
 
 import boto3
@@ -98,7 +97,6 @@ class SQSSourceActor(base.StreamingRaySource):
     async def run(self):
         while self.running:
             try:
-                start_time = time.time()
                 response = self.sqs_client.receive_message(
                     QueueUrl=self.queue_url,
                     AttributeNames=['All'],

--- a/buildflow/runtime/ray_io/sqs_io.py
+++ b/buildflow/runtime/ray_io/sqs_io.py
@@ -121,7 +121,7 @@ class SQSSourceActor(base.StreamingRaySource):
                 # TODO: we should look into abstracting the while loop in
                 # base.StreamingRaySource then new sources wouldn't have to
                 # worry about the shutdown / reporting metrics
-                self.update_metrics(num_messages, time.time() - start_time)
+                self.update_metrics(num_messages)
                 # Since SQS doesn't have an async client we need to
                 # sleep here to yield back the event loop. This allows us to
                 # collect metrics and shut down correctly.

--- a/buildflow/samples/bigquery_sample.py
+++ b/buildflow/samples/bigquery_sample.py
@@ -35,7 +35,8 @@ flow = Flow()
     # NOTE: You can alternatly just pass the table ID to read in an entire
     # table.
     source=buildflow.BigQuerySource(
-        query=f'SELECT COUNT(*) as count FROM `{args.input_table}`'),
+        query=f'SELECT COUNT(*) as count FROM `{args.input_table}`',
+        billing_project=args.input_table.split('.')[0]),
     sink=buildflow.BigQuerySink(table_id=args.output_table,
                                 temp_gcs_bucket=args.gcs_bucket))
 def process_query_result(dataset: ray.data.Dataset) -> Output:

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -52,4 +52,4 @@ def process(element: Dict[str, Any]) -> TaxiOutput:
 
 
 # Run our flow.
-flow.run().output()
+flow.run(streaming_options=buildflow.StreamingOptions(max_replicas=2)).output()

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -46,7 +46,7 @@ flow = Flow()
 
 
 # Define our processor.
-@flow.processor(source=input_sub, sink=output_table)
+@flow.processor(source=input_sub, sink=output_table, num_cpus=.1)
 def process(element: Dict[str, Any]) -> TaxiOutput:
     return element
 

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -52,4 +52,4 @@ def process(element: Dict[str, Any]) -> TaxiOutput:
 
 
 # Run our flow.
-flow.run(streaming_options=buildflow.StreamingOptions(max_replicas=2)).output()
+flow.run().output()

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -46,7 +46,7 @@ flow = Flow()
 
 
 # Define our processor.
-@flow.processor(source=input_sub, sink=output_table, num_cpus=.1)
+@flow.processor(source=input_sub, sink=output_table)
 def process(element: Dict[str, Any]) -> TaxiOutput:
     return element
 

--- a/buildflow/samples/sqs_walkthrough.py
+++ b/buildflow/samples/sqs_walkthrough.py
@@ -35,7 +35,6 @@ flow = Flow()
 
 @flow.processor(source=source, sink=sink)
 def process(element: Dict[str, Any]):
-    print('DO NOT SUBMIT IN PROCESS: ', datetime.datetime.now())
     time.sleep(5)
     return json.loads(element['Body'])
 

--- a/buildflow/samples/sqs_walkthrough.py
+++ b/buildflow/samples/sqs_walkthrough.py
@@ -6,8 +6,10 @@ See: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html
 """
 # flake8: noqa
 import argparse
+import datetime
 import json
 import sys
+import time
 from typing import Any, Dict
 
 import buildflow
@@ -17,14 +19,14 @@ from buildflow import Flow
 # Parser to allow run time configuration of arguments
 parser = argparse.ArgumentParser()
 parser.add_argument('--queue_name', type=str, required=True)
-parser.add_argument('--region', type=str, default='us-east-2')
+parser.add_argument('--region', type=str, default='us-east-1')
 parser.add_argument('--file_path',
                     type=str,
                     default='/tmp/buildflow/local_pubsub.parquet')
 args, _ = parser.parse_known_args(sys.argv)
 
 
-source = buildflow.SQSSource(queue_name=args.queue_name, region=args.region)
+source = buildflow.SQSSource(queue_name=args.queue_name, region=args.region, batch_size=1)
 sink = buildflow.FileSink(file_path=args.file_path,
                           file_format=buildflow.FileFormat.PARQUET)
 
@@ -33,6 +35,8 @@ flow = Flow()
 
 @flow.processor(source=source, sink=sink)
 def process(element: Dict[str, Any]):
+    print('DO NOT SUBMIT IN PROCESS: ', datetime.datetime.now())
+    time.sleep(5)
     return json.loads(element['Body'])
 
 

--- a/buildflow/samples/sqs_walkthrough.py
+++ b/buildflow/samples/sqs_walkthrough.py
@@ -35,7 +35,6 @@ flow = Flow()
 
 @flow.processor(source=source, sink=sink)
 def process(element: Dict[str, Any]):
-    time.sleep(5)
     return json.loads(element['Body'])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "buildflow"
-version = "0.0.13"
+version = "0.0.13.dev0"
 authors = [
     { name = "Caleb Van Dyke", email = "caleb@launchflow.com" },
     { name = "Josh Tanke", email = "josh@launchflow.com" },


### PR DESCRIPTION
Changes I added:
- 1:1 ratio for processor to source actors this helps scale much better
- Scale replicas based on total CPU used by a replica (source + sink + processor)
- provide batch size as a param for SQS. This allows users to have no batching of messages before processing.
- Allow users to specify how much CPU their processor should use (defaults to .5).
- The manager now does "checkins" with all replicas instead of the "autoscaling". This checkin updates metrics and does the autoscaling. Moving the metrics here helped speed up the processing logic because sometimes reporting metrics can be slow so this removes it from that loop

Examples:
Specify batch size:
```
source = buildflow.SQSSource(queue_name=args.queue_name, region=args.region, batch_size=1)
```

Specify CPU:
```
@flow.processor(source=source, sink=sink, num_cpus=.5)
def process(element: Dict[str, Any]):
    ...
```