### PR TITLE
feat: add plan command to buildflow

### DIFF
--- a/buildflow/api/__init__.py
+++ b/buildflow/api/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
-from .node import NodeAPI, NodeResults
+from .node import NodeAPI, NodePlan, NodeResults
 from .io import SinkType, SourceType
-from .processor import ProcessorAPI
-from .options import StreamingOptions
+from .processor import ProcessorAPI, ProcessorPlan
+from .options import AutoscalingOptions
 
 # NOTE: Only API code should go into this directory. Any runtime code should go
 # into the runtime directory.

--- a/buildflow/api/grid.py
+++ b/buildflow/api/grid.py
@@ -1,7 +1,14 @@
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Iterable
 
-from buildflow.api.node import NodeAPI
+from buildflow.api.node import NodeAPI, NodePlan
 from buildflow.utils import uuid
+
+
+@dataclass
+class GridPlan:
+    name: str
+    nodes: Iterable[NodePlan]
 
 
 class GridNode:
@@ -37,3 +44,11 @@ class GridAPI:
 
     def deploy(self):
         pass
+
+    def plan(self):
+        node_plans = [node.plan() for node in self.nodes.values()]
+        return GridPlan(name=self.name, nodes=node_plans)
+
+    def setup(self):
+        for node in self.nodes.values():
+            node.setup()

--- a/buildflow/api/io.py
+++ b/buildflow/api/io.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import inspect
-from typing import Any, Callable, Optional, Type, TypeVar
+from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
 from buildflow.api.depends import DependsPublisher
 
@@ -18,6 +18,9 @@ class _BaseIO:
         # TODO: we should probably make this configurable though to help
         # prevent OOMs.
         return 0.1
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        pass
 
 
 class Source(_BaseIO):

--- a/buildflow/api/node.py
+++ b/buildflow/api/node.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional
+import dataclasses
+from typing import Any, Iterable, Optional
 
-from buildflow.api import options
-from buildflow.api.processor import ProcessorAPI
+from buildflow.api.processor import ProcessorAPI, ProcessorPlan
 
 
 class NodeResults:
@@ -17,6 +17,12 @@ class NodeResults:
         pass
 
 
+@dataclasses.dataclass
+class NodePlan:
+    name: Optional[str]
+    processors: Iterable[ProcessorPlan]
+
+
 class NodeAPI:
     def __init__(self, name) -> None:
         self.name = name
@@ -29,9 +35,14 @@ class NodeAPI:
 
     def run(
         *,
-        streaming_options: options.StreamingOptions = options.StreamingOptions(),
         disable_usage_stats: bool = False,
-        enable_resource_creation: bool = True,
+        disable_resource_creation: bool = True,
         blocking: bool = True,
     ):
+        pass
+
+    def plan(self) -> NodePlan:
+        pass
+
+    def setup():
         pass

--- a/buildflow/api/options.py
+++ b/buildflow/api/options.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 
 @dataclass
-class StreamingOptions:
+class AutoscalingOptions:
     # The minimum number of replicas to maintain.
     min_replicas: int = 1
     # The maximum number of replicas to scale up to.

--- a/buildflow/api/processor.py
+++ b/buildflow/api/processor.py
@@ -1,6 +1,8 @@
-from typing import Any, Iterable
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
 
 from buildflow.api.io import SourceType, SinkType
+from buildflow.api.options import AutoscalingOptions
 
 
 class ProcessorAPI:
@@ -32,3 +34,13 @@ class ProcessorAPI:
 
     def num_cpus(self) -> float:
         return 0.5
+
+    def autoscaling_options(self) -> AutoscalingOptions:
+        return AutoscalingOptions()
+
+
+@dataclass
+class ProcessorPlan:
+    name: str
+    source_resources: Dict[str, Any]
+    sink_resources: Optional[Dict[str, Any]]

--- a/buildflow/cli/main.py
+++ b/buildflow/cli/main.py
@@ -1,32 +1,76 @@
+from dataclasses import asdict
 import sys
 
 import typer
+import yaml
 
 import buildflow
 from buildflow.cli import utils
 
-app = typer.Typer()
+BUILDFLOW_HELP = """\
+Welcome to the buildflow CLI!
+
+Use the `run` command to run your buildflow nodes.
+
+Use the `deploy` command to deploy your entire grid.
+
+Use the `plan` command to see what resources will be used by your nodes and grids.
+"""
+app = typer.Typer(help=BUILDFLOW_HELP)
 
 APP_DIR_OPTION = typer.Option(
     "",
     help=(
         "The directory to look for the app in, by adding this to `sys.path` "
-        "we default to looking in the current working directory."
+        "we default to looking in the directory."
     ),
 )
 
 
-@app.command(help="Run a buildflow node or grid.")
+@app.command(help="Run a buildflow node.")
 def run(
-    app: str = typer.Argument(..., help="The app to run"),
+    app: str = typer.Argument(..., help="The node app to run"),
+    disable_usage_stats: bool = typer.Option(
+        False, help="Disable buildflow usage stats"
+    ),
+    disable_resource_creation: bool = typer.Option(
+        False, help="Disable resource creation"
+    ),
     app_dir: str = APP_DIR_OPTION,
 ):
     sys.path.insert(0, app_dir)
     imported = utils.import_from_string(app)
     if isinstance(imported, buildflow.Node):
-        imported.run()
+        imported.run(
+            disable_usage_stats=disable_usage_stats,
+            disable_resource_creation=disable_resource_creation,
+        )
+    else:
+        typer.echo(f"{app} is not a buildflow node.")
+        raise typer.Exit(1)
+
+
+@app.command(help="Deploy a buildflow grid.")
+def deploy(
+    app: str = typer.Argument(..., help="The grid app to run"),
+    disable_usage_stats: bool = typer.Option(
+        False, help="Disable buildflow usage stats"
+    ),
+    disable_resource_creation: bool = typer.Option(
+        False, help="Disable resource creation"
+    ),
+    app_dir: str = APP_DIR_OPTION,
+):
+    sys.path.insert(0, app_dir)
+    imported = utils.import_from_string(app)
     if isinstance(imported, buildflow.DeploymentGrid):
-        imported.deploy()
+        imported.deploy(
+            disable_usage_stats=disable_usage_stats,
+            disable_resource_creation=disable_resource_creation,
+        )
+    else:
+        typer.echo(f"{app} is not a buildflow node.")
+        raise typer.Exit(1)
 
 
 @app.command(help="Output all resources used by a buildflow node or grid")
@@ -35,7 +79,28 @@ def plan(
     app_dir: str = APP_DIR_OPTION,
 ):
     sys.path.insert(0, app_dir)
-    raise NotImplementedError("Not implemented yet")
+    imported = utils.import_from_string(app)
+    if isinstance(imported, (buildflow.Node, buildflow.DeploymentGrid)):
+        plan = imported.plan()
+        print(yaml.dump(asdict(plan), sort_keys=False))
+        print()
+        user_input = ""
+        while True:
+            user_input = input(
+                "Would you like to setup the resources for this plan (Y/n)? "
+            )
+            if user_input.lower() not in ["y", "n"]:
+                print('Please enter "y" or "n"')
+            else:
+                break
+
+        if user_input == "n":
+            return
+        imported.setup()
+
+    else:
+        typer.echo("plan must be run on a node, or deployment grid")
+        typer.Exit(1)
 
 
 def main():

--- a/buildflow/runtime/grid.py
+++ b/buildflow/runtime/grid.py
@@ -14,13 +14,25 @@ async def shutdown(results):
 
 
 class DeploymentGrid(grid.GridAPI):
-    def deploy(self):
-        asyncio.run(self._deploy_async())
+    def deploy(
+        self,
+        disable_usage_stats: bool = False,
+        disable_resource_creation: bool = False,
+    ):
+        asyncio.run(self._deploy_async(disable_usage_stats, disable_resource_creation))
 
-    async def _deploy_async(self):
+    async def _deploy_async(
+        self, disable_usage_stats: bool, disable_resource_creation: bool
+    ):
         results = []
         for node in self.nodes.values():
-            results.append(node.node.run(blocking=False))
+            results.append(
+                node.node.run(
+                    blocking=False,
+                    disable_usage_stats=disable_usage_stats,
+                    disable_resource_creation=disable_resource_creation,
+                )
+            )
 
         coros = [result.output(register_shutdown=False) for result in results]
         loop = asyncio.get_event_loop()

--- a/buildflow/runtime/managers/auto_scaler.py
+++ b/buildflow/runtime/managers/auto_scaler.py
@@ -19,7 +19,7 @@ from typing import List
 import ray
 from ray.autoscaler.sdk import request_resources
 
-from buildflow.api.options import StreamingOptions
+from buildflow.api.options import AutoscalingOptions
 
 _TARGET_UTILIZATION = 0.5
 
@@ -37,7 +37,7 @@ def get_recommended_num_replicas(
     events_processed_per_replica: List[int],
     non_empty_ratio_per_replica: List[float],
     time_since_last_check: float,
-    autoscaling_options: StreamingOptions,
+    autoscaling_options: AutoscalingOptions,
     cpus_per_replica: float,
 ) -> int:
     non_empty_ratio_sum = sum(non_empty_ratio_per_replica)

--- a/buildflow/runtime/managers/auto_scaler_test.py
+++ b/buildflow/runtime/managers/auto_scaler_test.py
@@ -31,7 +31,7 @@ class AutoScalerTest(unittest.TestCase):
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
                 cpus_per_replica=0.1,
-                autoscaling_options=options.StreamingOptions(),
+                autoscaling_options=options.AutoscalingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
             expected_log = "resizing from 3 replicas to 8 replicas"
@@ -63,7 +63,7 @@ class AutoScalerTest(unittest.TestCase):
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
                 cpus_per_replica=0.1,
-                autoscaling_options=options.StreamingOptions(),
+                autoscaling_options=options.AutoscalingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
             expected_log = "resizing from 24 replicas to 6 replicas"
@@ -92,7 +92,7 @@ class AutoScalerTest(unittest.TestCase):
                 cpus_per_replica=0.1,
                 # Max replicas will cap recommendation. Even though we need 8
                 # to burn down the backlog we won't scale beyond max_replicas.
-                autoscaling_options=options.StreamingOptions(max_replicas=5),
+                autoscaling_options=options.AutoscalingOptions(max_replicas=5),
             )
             self.assertEqual(len(self._caplog.records), 2)
             expected_log = "reached the max allowed replicas of 5"
@@ -125,7 +125,7 @@ class AutoScalerTest(unittest.TestCase):
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
                 cpus_per_replica=0.5,
-                autoscaling_options=options.StreamingOptions(max_replicas=85),
+                autoscaling_options=options.AutoscalingOptions(max_replicas=85),
             )
             self.assertEqual(len(self._caplog.records), 2)
             expected_log = (
@@ -160,7 +160,7 @@ class AutoScalerTest(unittest.TestCase):
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
                 cpus_per_replica=0.1,
-                autoscaling_options=options.StreamingOptions(max_replicas=84),
+                autoscaling_options=options.AutoscalingOptions(max_replicas=84),
             )
             self.assertEqual(len(self._caplog.records), 2)
             expected_log = "reached the max allowed replicas of 84"
@@ -193,7 +193,7 @@ class AutoScalerTest(unittest.TestCase):
                 non_empty_ratio_per_replica=non_empty_ratio_per_replica,
                 time_since_last_check=60,
                 cpus_per_replica=0.1,
-                autoscaling_options=options.StreamingOptions(),
+                autoscaling_options=options.AutoscalingOptions(),
             )
             self.assertEqual(len(self._caplog.records), 1)
             expected_log = "resizing from 24 replicas to 15 replicas"
@@ -227,7 +227,7 @@ class AutoScalerTest(unittest.TestCase):
                 time_since_last_check=120,
                 cpus_per_replica=0.1,
                 # Don't scale below 18 replicas.
-                autoscaling_options=options.StreamingOptions(min_replicas=18),
+                autoscaling_options=options.AutoscalingOptions(min_replicas=18),
             )
             self.assertEqual(len(self._caplog.records), 2)
             expected_log = "reached the minimum allowed replicas of 18"

--- a/buildflow/runtime/managers/stream_manager.py
+++ b/buildflow/runtime/managers/stream_manager.py
@@ -25,7 +25,7 @@ import ray
 from ray.util.metrics import Counter, Gauge
 
 from buildflow import utils
-from buildflow.api.options import StreamingOptions
+from buildflow.api.options import AutoscalingOptions
 from buildflow.runtime.managers import auto_scaler
 from buildflow.runtime.managers import processors
 from buildflow.runtime.ray_io import empty_io
@@ -82,7 +82,7 @@ async def _wait_for_metrics(
 class _StreamManagerActor:
     def __init__(
         self,
-        options: StreamingOptions,
+        options: AutoscalingOptions,
         proc_id: str,
         processor_ref: processors.ProcessorRef,
         proc_input_type: Optional[Type],
@@ -263,11 +263,13 @@ class StreamProcessManager:
         self,
         processor_ref: processors.ProcessorRef,
         proc_id: str,
-        streaming_options: StreamingOptions,
         proc_input_type: Optional[Type],
     ) -> None:
         self._actor = _StreamManagerActor.options(namespace=proc_id).remote(
-            streaming_options, proc_id, processor_ref, proc_input_type
+            processor_ref.processor_instance.autoscaling_options(),
+            proc_id,
+            processor_ref,
+            proc_input_type,
         )
         self.manager_task = None
 

--- a/buildflow/runtime/node.py
+++ b/buildflow/runtime/node.py
@@ -11,9 +11,13 @@ class Node(node.NodeAPI):
         self._runtime = Runtime()
 
     def processor(
-        self, source: SourceType, sink: Optional[SinkType] = None, num_cpus: float = 0.5
+        self,
+        source: SourceType,
+        sink: Optional[SinkType] = None,
+        num_cpus: float = 0.5,
+        autoscaling_options: options.AutoscalingOptions = options.AutoscalingOptions(),
     ):
-        return processor(self._runtime, source, sink, num_cpus)
+        return processor(self._runtime, source, sink, num_cpus, autoscaling_options)
 
     def add_processor(self, processor: ProcessorAPI):
         self._runtime.register_processor(processor)
@@ -21,15 +25,20 @@ class Node(node.NodeAPI):
     def run(
         self,
         *,
-        streaming_options: options.StreamingOptions = options.StreamingOptions(),
         disable_usage_stats: bool = False,
-        enable_resource_creation: bool = True,
+        disable_resource_creation: bool = True,
         blocking: bool = True,
     ) -> node.NodeResults:
+        if not disable_resource_creation:
+            self._runtime.setup()
         return self._runtime.run(
-            streaming_options=streaming_options,
             disable_usage_stats=disable_usage_stats,
-            enable_resource_creation=enable_resource_creation,
             node_name=self.name,
             blocking=blocking,
         )
+
+    def plan(self) -> node.NodePlan:
+        return self._runtime.plan(node_name=self.name)
+
+    def setup(self):
+        return self._runtime.setup()

--- a/buildflow/runtime/processor.py
+++ b/buildflow/runtime/processor.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Optional
 
 from buildflow import utils
-from buildflow.api import ProcessorAPI
+from buildflow.api import ProcessorAPI, AutoscalingOptions
 from buildflow.api.io import SinkType, SourceType
 from buildflow.runtime import Runtime
 from buildflow.runtime.ray_io import empty_io
@@ -31,6 +31,7 @@ def processor(
     source: SourceType,
     sink: Optional[SinkType] = None,
     num_cpus: float = 0.5,
+    autoscaling_options: AutoscalingOptions = AutoscalingOptions(),
 ):
     if sink is None:
         sink = empty_io.EmptySink()
@@ -60,6 +61,7 @@ def processor(
                 ),
                 "num_cpus": lambda self: num_cpus,
                 "__call__": wrapper_function,
+                "autoscaling_options": lambda self: autoscaling_options,
             },
         )
         processor_instance = _AdHocProcessor()

--- a/buildflow/runtime/ray_io/datawarehouse_io.py
+++ b/buildflow/runtime/ray_io/datawarehouse_io.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Callable, Union
+from typing import Any, Callable, Dict, Union
 
 from buildflow.api import io
 from buildflow.runtime.ray_io import bigquery_io
@@ -27,6 +27,9 @@ class DataWarehouseSink(io.Sink):
             self._cloud_sink = bigquery_io.BigQuerySink(**self.cloud_args)
         else:
             raise ValueError(f"Unsupported cloud: {self.cloud}")
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        return self._cloud_sink.plan(process_arg_spec)
 
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         return self._cloud_sink.setup(process_arg_spec)

--- a/buildflow/runtime/ray_io/datawarehouse_io_test.py
+++ b/buildflow/runtime/ray_io/datawarehouse_io_test.py
@@ -1,0 +1,45 @@
+import unittest
+
+import buildflow
+from buildflow.api import NodePlan, ProcessorPlan
+from buildflow.runtime.ray_io import empty_io
+from buildflow.runtime.ray_io import datawarehouse_io
+
+
+class TestDataWarehouseIO(unittest.TestCase):
+    def test_gcp_datawarehouse_io_plan(self):
+        expected_plan = NodePlan(
+            name="",
+            processors=[
+                ProcessorPlan(
+                    name="dw_process",
+                    source_resources={
+                        "source_type": "EmptySource",
+                    },
+                    sink_resources={
+                        "sink_type": "DataWarehouseSink",
+                        "table": {
+                            "table_id": "p.buildflow_default.table",
+                            "schema": None,
+                        },
+                    },
+                )
+            ],
+        )
+        app = buildflow.Node()
+
+        @app.processor(
+            source=empty_io.EmptySource([]),
+            sink=datawarehouse_io.DataWarehouseSink(
+                cloud="gcp", name="table", project_id="p"
+            ),
+        )
+        def dw_process(elem):
+            pass
+
+        plan = app.plan()
+        self.assertEqual(expected_plan, plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/buildflow/runtime/ray_io/file_io.py
+++ b/buildflow/runtime/ray_io/file_io.py
@@ -1,7 +1,8 @@
 """IO for writing to local files."""
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
+import inspect
 import os
 import json
 from pathlib import Path
@@ -25,6 +26,11 @@ class FileFormat(Enum):
 
 
 @dataclass
+class _FileSourcePlan:
+    file_path: str
+
+
+@dataclass
 class FileSink(io.Sink):
     file_path: str
     file_format: FileFormat
@@ -37,6 +43,9 @@ class FileSink(io.Sink):
         split_path = os.path.split(abs_path)
         if split_path[0]:
             os.makedirs(os.path.join(split_path[0]), exist_ok=True)
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        return asdict(_FileSourcePlan(self.file_path))
 
     def actor(self, remote_fn: Callable, is_streaming: bool):
         return FileSinkActor.remote(remote_fn, self)

--- a/buildflow/runtime/ray_io/gcs_io.py
+++ b/buildflow/runtime/ray_io/gcs_io.py
@@ -1,4 +1,5 @@
 import dataclasses
+import inspect
 import logging
 from typing import Any, Dict, List, Optional, Type
 
@@ -8,6 +9,13 @@ from buildflow.api import io
 from buildflow.runtime.ray_io import gcp_pubsub_io
 from buildflow.runtime.ray_io import gcp_pubsub_utils
 from buildflow.runtime.ray_io.gcp import clients
+
+
+@dataclasses.dataclass
+class _GCSSourcePlan:
+    bucket_name: str
+    pubsub_topic: str
+    pubsub_subscription: str
 
 
 @dataclasses.dataclass
@@ -76,6 +84,15 @@ class GCSFileNotifications(io.StreamingSource):
         )
         if not self.billing_project:
             self.billing_project = self.project_id
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        return dataclasses.asdict(
+            _GCSSourcePlan(
+                bucket_name=self.bucket_name,
+                pubsub_topic=self.pubsub_topic,
+                pubsub_subscription=self.pubsub_subscription,
+            )
+        )
 
     def setup(self):
         # TODO: Can we make the pubsub setup easier by just running:

--- a/buildflow/runtime/ray_io/pubsub_io.py
+++ b/buildflow/runtime/ray_io/pubsub_io.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Callable, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from buildflow.api import io
 from buildflow.api.depends import Publisher
@@ -26,6 +26,9 @@ class PubSubSource(io.StreamingSource):
             self._cloud_source = gcp_pubsub_io.GCPPubSubSource(**self.cloud_args)
         else:
             raise ValueError(f"Unsupported cloud: {self.cloud}")
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        return self._cloud_source.plan(process_arg_spec)
 
     def setup(self):
         return self._cloud_source.setup()
@@ -62,6 +65,9 @@ class PubSubSink(io.Sink):
             self._cloud_sink = gcp_pubsub_io.GCPPubSubSink(**self.cloud_args)
         else:
             raise ValueError(f"Unsupported cloud: {self.cloud}")
+
+    def plan(self, process_arg_spec: inspect.FullArgSpec) -> Dict[str, Any]:
+        return self._cloud_sink.plan(process_arg_spec)
 
     def setup(self, process_arg_spec: inspect.FullArgSpec):
         return self._cloud_sink.setup(process_arg_spec)

--- a/buildflow/runtime/ray_io/pubsub_io_test.py
+++ b/buildflow/runtime/ray_io/pubsub_io_test.py
@@ -1,0 +1,41 @@
+import unittest
+
+import buildflow
+from buildflow.api import NodePlan, ProcessorPlan
+from buildflow.runtime.ray_io import pubsub_io
+
+
+class TestPubSubIO(unittest.TestCase):
+    def test_pubsub_io_plan(self):
+        expected_plan = NodePlan(
+            name="",
+            processors=[
+                ProcessorPlan(
+                    name="ps_process",
+                    source_resources={
+                        "source_type": "PubSubSource",
+                        "topic": "projects/p/topics/source",
+                        "subscription": "projects/p/subscriptions/source",
+                    },
+                    sink_resources={
+                        "sink_type": "PubSubSink",
+                        "topic": "projects/p/topics/source",
+                    },
+                )
+            ],
+        )
+        app = buildflow.Node()
+
+        @app.processor(
+            source=pubsub_io.PubSubSource(cloud="gcp", name="source", project_id="p"),
+            sink=pubsub_io.PubSubSink(cloud="gcp", name="source", project_id="p"),
+        )
+        def ps_process(elem):
+            pass
+
+        plan = app.plan()
+        self.assertEqual(expected_plan, plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/buildflow/runtime/ray_io/redis_stream_io_test.py
+++ b/buildflow/runtime/ray_io/redis_stream_io_test.py
@@ -50,12 +50,12 @@ class RedisStreamTest(unittest.TestCase):
             sink=buildflow.RedisStreamSink(
                 host="localhost", port=8765, streams=["output_stream"]
             ),
+            autoscaling_options=buildflow.AutoscalingOptions(autoscaling=False),
         )
         def process(element):
             return element
 
         runner = self.app.run(
-            streaming_options=buildflow.StreamingOptions(autoscaling=False),
             blocking=False,
         )
         time.sleep(10)
@@ -83,12 +83,12 @@ class RedisStreamTest(unittest.TestCase):
             sink=buildflow.RedisStreamSink(
                 host="localhost", port=8765, streams=["output_stream"]
             ),
+            autoscaling_options=buildflow.AutoscalingOptions(autoscaling=False),
         )
         def process(element):
             return [element, element]
 
         runner = self.app.run(
-            streaming_options=buildflow.StreamingOptions(autoscaling=False),
             blocking=False,
         )
         time.sleep(10)
@@ -115,12 +115,12 @@ class RedisStreamTest(unittest.TestCase):
             sink=buildflow.RedisStreamSink(
                 host="localhost", port=8765, streams=["output_stream"]
             ),
+            autoscaling_options=buildflow.AutoscalingOptions(autoscaling=False),
         )
         def process(element):
             return Output(element["field"])
 
         runner = self.app.run(
-            streaming_options=buildflow.StreamingOptions(autoscaling=False),
             blocking=False,
         )
         time.sleep(10)
@@ -148,12 +148,12 @@ class RedisStreamTest(unittest.TestCase):
             sink=buildflow.RedisStreamSink(
                 host="localhost", port=8765, streams=["output_stream"]
             ),
+            autoscaling_options=buildflow.AutoscalingOptions(autoscaling=False),
         )
         def process(element):
             return [Output(element["field"]), Output(element["field"])]
 
         runner = self.app.run(
-            streaming_options=buildflow.StreamingOptions(autoscaling=False),
             blocking=False,
         )
         time.sleep(10)

--- a/buildflow/runtime/ray_io/schemas/bigquery.py
+++ b/buildflow/runtime/ray_io/schemas/bigquery.py
@@ -55,20 +55,20 @@ def dataclass_to_bq_schema(fields: dataclasses.Field) -> List[bigquery.SchemaFie
     return bq_fields
 
 
-def _schema_field_to_dict(schema_field: bigquery.SchemaField) -> Dict[str, Any]:
+def schema_field_to_dict(schema_field: bigquery.SchemaField) -> Dict[str, Any]:
     field_dict = {
         "name": schema_field.name,
         "type": schema_field.field_type,
         "mode": schema_field.mode,
     }
     if schema_field.fields:
-        field_dict["fields"] = [_schema_field_to_dict(f) for f in schema_field.fields]
+        field_dict["fields"] = [schema_field_to_dict(f) for f in schema_field.fields]
 
     return field_dict
 
 
 def schema_fields_to_str(schema_fields: List[bigquery.SchemaField]) -> str:
     yaml_objs = [
-        yaml.dump(_schema_field_to_dict(f), sort_keys=False) for f in schema_fields
+        yaml.dump(schema_field_to_dict(f), sort_keys=False) for f in schema_fields
     ]
     return "\n\n".join(yaml_objs)

--- a/buildflow/runtime/ray_io/sqs_io_test.py
+++ b/buildflow/runtime/ray_io/sqs_io_test.py
@@ -176,6 +176,7 @@ class SqsIoTest(unittest.TestCase):
     @mock_sqs
     @mock_sts
     def test_sqs_source_plan(self):
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-9"
         expected_plan = NodePlan(
             name="",
             processors=[
@@ -183,7 +184,7 @@ class SqsIoTest(unittest.TestCase):
                     name="sqs_process",
                     source_resources={
                         "source_type": "SQSSource",
-                        "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/queue_name",
+                        "queue_url": "https://sqs.us-east-9.amazonaws.com/123456789012/queue_name",
                     },
                     sink_resources=None,
                 )

--- a/buildflow/samples/bigquery_sample.py
+++ b/buildflow/samples/bigquery_sample.py
@@ -39,3 +39,7 @@ gcs_bucket = os.environ["GCS_BUCKET"]
 def process_query_result(dataset: ray.data.Dataset) -> Output:
     # TODO: process the dataset (bq query result).
     return dataset
+
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/class_sample.py
+++ b/buildflow/samples/class_sample.py
@@ -43,3 +43,6 @@ class MyProcessor(buildflow.Processor):
 
 
 app.add_processor(MyProcessor())
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/csv_bigquery_walkthrough.py
+++ b/buildflow/samples/csv_bigquery_walkthrough.py
@@ -79,3 +79,7 @@ def process(gcs_file_event: buildflow.GCSFileEvent) -> List[AggregateWikiPageVie
             )
 
     return list(aggregate_stats.values())
+
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/decorator_sample.py
+++ b/buildflow/samples/decorator_sample.py
@@ -25,3 +25,7 @@ app = Node()
 def process(taxi_info):
     print(taxi_info)
     return taxi_info
+
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/local_pubsub_walkthrough.py
+++ b/buildflow/samples/local_pubsub_walkthrough.py
@@ -26,10 +26,14 @@ input_sub = buildflow.GCPPubSubSource(
 # Set up a FileSink for writing to a file locally.
 sink = buildflow.FileSink(file_path=file_path, file_format=buildflow.FileFormat.PARQUET)
 
-node = Node()
+app = Node()
 
 
 # Define our processor.
-@node.processor(source=input_sub, sink=sink)
+@app.processor(source=input_sub, sink=sink)
 def process(element: Dict[str, Any]):
     return element
+
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/notebook_sample.ipynb
+++ b/buildflow/samples/notebook_sample.ipynb
@@ -28,18 +28,18 @@
         "_INPUT_TABLE_ID1 = ''\n",
         "_INPUT_TABLE_ID2 = ''\n",
         "\n",
-        "node = Node()\n",
+        "app = Node()\n",
         "\n",
-        "@node.processor(source=buildflow.BigQuery(table_id=_INPUT_TABLE_ID1))\n",
+        "@app.processor(source=buildflow.BigQuery(table_id=_INPUT_TABLE_ID1))\n",
         "def process_table1(table: ray.data.Dataset):\n",
         "    return table\n",
         "\n",
-        "@node.processor(source=buildflow.BigQuery(table_id=_INPUT_TABLE_ID2))\n",
+        "@app.processor(source=buildflow.BigQuery(table_id=_INPUT_TABLE_ID2))\n",
         "def process_table2(table: ray.data.Dataset):\n",
         "    return table\n",
         "# NOTE: It is best to keep flow.run and your processor definition in the same\n",
         "# code block.\n",
-        "output = node.run().output()"
+        "output = app.run().output()"
       ]
     },
     {

--- a/buildflow/samples/pubsub_walkthrough.py
+++ b/buildflow/samples/pubsub_walkthrough.py
@@ -45,3 +45,7 @@ app = Node()
 @app.processor(source=input_sub, sink=output_table)
 def process(element: Dict[str, Any]) -> TaxiOutput:
     return element
+
+
+if __name__ == "__main__":
+    app.run()

--- a/buildflow/samples/sqs_walkthrough.py
+++ b/buildflow/samples/sqs_walkthrough.py
@@ -19,13 +19,9 @@ file_path = os.environ.get("OUTPUT_FILE_PATH", "/tmp/buildflow/local_pubsub.parq
 source = buildflow.SQSSource(queue_name=queue_name, region=region, batch_size=1)
 sink = buildflow.FileSink(file_path=file_path, file_format=buildflow.FileFormat.PARQUET)
 
-flow = Node()
+app = Node()
 
 
-@flow.processor(source=source, sink=sink)
+@app.processor(source=source, sink=sink)
 def process(element: Dict[str, Any]):
     return json.loads(element["Body"])
-
-
-# Run our flow.
-flow.run().output()

--- a/buildflow/samples/sqs_walkthrough.py
+++ b/buildflow/samples/sqs_walkthrough.py
@@ -25,3 +25,7 @@ app = Node()
 @app.processor(source=source, sink=sink)
 def process(element: Dict[str, Any]):
     return json.loads(element["Body"])
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Here's an example of what it looks like for a gcs file notifications pipeline:

```
name: ''
processors:
- name: ImageClassificationProcessor
  source_resources:
    source_type: GCSFileNotifications
    bucket_name: caleb-image-classification
    pubsub_topic: projects/daring-runway-374503/topics/caleb-image-classification_notifications
    pubsub_subscription: projects/daring-runway-374503/subscriptions/caleb-image-classification_subscriber
  sink_resources:
    sink_type: BigQuerySink
    table:
      table_id: daring-runway-374503.launchflow_walkthrough.image_classification
      schema:
      - name: classifications
        type: RECORD
        mode: REPEATED
        fields:
        - name: classification
          type: STRING
          mode: REQUIRED
        - name: confidence
          type: FLOAT
          mode: REQUIRED
      - name: image_name
        type: STRING
        mode: REQUIRED
      - name: upload
        type: STRING
        mode: REQUIRED

Would you like to setup the resources for this plan (Y/n)? n
```