### PR TITLE
fix: update autoscaler to use cpu percentage for downscaling

### DIFF
--- a/buildflow/__init__.py
+++ b/buildflow/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa
-from buildflow.core import *
+from .core.app.flow import Flow
+from .core.options.flow_options import FlowOptions

--- a/buildflow/core/__init__.py
+++ b/buildflow/core/__init__.py
@@ -1,2 +1,0 @@
-# ruff: noqa
-from .app.flow import Flow

--- a/buildflow/core/app/runtime/actors/pipeline_pattern/pipeline_pool.py
+++ b/buildflow/core/app/runtime/actors/pipeline_pattern/pipeline_pool.py
@@ -4,7 +4,7 @@ import logging
 from typing import List
 
 import ray
-from ray.exceptions import RayActorError
+from ray.exceptions import RayActorError, OutOfMemoryError
 
 from buildflow.core import utils
 from buildflow.core.app.runtime.actors.pipeline_pattern.pull_process_push import (
@@ -123,7 +123,7 @@ class PipelineProcessorReplicaPoolActor(ProcessorReplicaPoolActor):
                     await replica.ray_actor_handle.snapshot.remote()
                 )
                 replica_snapshots.append(snapshot)
-            except RayActorError:
+            except (RayActorError, OutOfMemoryError):
                 logging.exception("replica actor unexpectedly died. will restart.")
                 # We keep this list reverse sorted so we can iterate and remove
                 dead_replica_indices.appendleft(i)

--- a/buildflow/core/app/runtime/actors/pipeline_pattern/pipeline_pool.py
+++ b/buildflow/core/app/runtime/actors/pipeline_pattern/pipeline_pool.py
@@ -7,6 +7,7 @@ import ray
 from ray.exceptions import RayActorError
 from ray.util.placement_group import (
     placement_group,
+    remove_placement_group,
 )
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
@@ -146,7 +147,8 @@ class PipelineProcessorReplicaPoolActor(ProcessorReplicaPoolActor):
                 # We keep this list reverse sorted so we can iterate and remove
                 dead_replica_indices.appendleft(i)
         for idx in dead_replica_indices:
-            self.replicas.pop(idx)
+            replica = self.replicas.pop(idx)
+            remove_placement_group(replica.ray_placement_group)
         if dead_replica_indices:
             logging.error("removed %s dead replicas", len(dead_replica_indices))
             # update our gauge if had to remove some replicas.

--- a/buildflow/core/app/runtime/actors/pipeline_pattern/pull_process_push.py
+++ b/buildflow/core/app/runtime/actors/pipeline_pattern/pull_process_push.py
@@ -2,8 +2,10 @@ import asyncio
 import dataclasses
 import inspect
 import logging
+import os
 import time
 
+import psutil
 import ray
 
 from buildflow.core import utils
@@ -37,6 +39,7 @@ class PullProcessPushSnapshot(Snapshot):
     process_time_millis: RateCalculation
     process_batch_time_millis: RateCalculation
     pull_to_ack_time_millis: RateCalculation
+    cpu_percentage: RateCalculation
 
     def as_dict(self) -> dict:
         return {
@@ -47,13 +50,19 @@ class PullProcessPushSnapshot(Snapshot):
             "process_time_millis": self.process_time_millis.average_value_rate(),
             "process_batch_time_millis": self.process_batch_time_millis.average_value_rate(),  # noqa: E501
             "pull_to_ack_time_millis": self.pull_to_ack_time_millis.average_value_rate(),  # noqa: E501
+            "cpu_percentage": self.cpu_percentage.average_value_rate(),
         }
 
 
 @ray.remote
 class PullProcessPushActor(Runtime):
     def __init__(
-        self, run_id: RunID, processor: PipelineProcessor, *, log_level: str = "INFO"
+        self,
+        run_id: RunID,
+        processor: PipelineProcessor,
+        *,
+        replica_id,
+        log_level: str = "INFO",
     ) -> None:
         # NOTE: Ray actors run in their own process, so we need to configure
         # logging per actor / remote task.
@@ -72,6 +81,7 @@ class PullProcessPushActor(Runtime):
         # initial runtime state
         self._status = RuntimeStatus.IDLE
         self._num_running_threads = 0
+        self._replica_id = replica_id
         self._last_snapshot_time = time.monotonic()
         # metrics
         self.max_batch_size = self.processor.source().max_batch_size()
@@ -125,8 +135,20 @@ class PullProcessPushActor(Runtime):
                 "RunId": self.run_id,
             },
         )
+        self.cpu_percentage = CompositeRateCounterMetric(
+            "cpu_percentage",
+            description="Current CPU percentage of a replica. Goes up and down.",
+            default_tags={
+                "processor_id": processor.processor_id,
+                "JobId": job_id,
+                "RunId": self.run_id,
+                "ReplicaID": self._replica_id,
+            },
+        )
 
     async def run(self):
+        pid = os.getpid()
+        proc = psutil.Process(pid)
         if self._status == RuntimeStatus.IDLE:
             logging.info("Starting PullProcessPushActor...")
             self._status = RuntimeStatus.RUNNING
@@ -176,6 +198,7 @@ class PullProcessPushActor(Runtime):
                 return push_converter(results)
 
         while self._status == RuntimeStatus.RUNNING:
+            proc.cpu_percent()
             # PULL
             total_start_time = time.monotonic()
             try:
@@ -185,7 +208,12 @@ class PullProcessPushActor(Runtime):
                 continue
             if not response.payload:
                 self._pull_percentage_counter.empty_inc()
-                await asyncio.sleep(1)
+                # TODO: test removing this
+                # await asyncio.sleep(1)
+                cpu_percent = proc.cpu_percent()
+                if cpu_percent > 0.0:
+                    # Ray doesn't like it when we try to set a metric to 0
+                    self.cpu_percentage.inc(cpu_percent)
                 continue
             # PROCESS
             process_success = True
@@ -229,6 +257,10 @@ class PullProcessPushActor(Runtime):
             self.num_events_processed.inc(len(response.payload))
             # DONE -> LOOP
             self.total_time_counter.inc((time.monotonic() - total_start_time) * 1000)
+            cpu_percent = proc.cpu_percent()
+            if cpu_percent > 0.0:
+                # Ray doesn't like it when we try to set a metric to 0
+                self.cpu_percentage.inc(cpu_percent)
 
         self._num_running_threads -= 1
         if self._num_running_threads == 0:
@@ -250,14 +282,16 @@ class PullProcessPushActor(Runtime):
         return True
 
     async def snapshot(self):
+        throughput = self.num_events_processed.calculate_rate()
         snapshot = PullProcessPushSnapshot(
             status=self._status,
             timestamp_millis=utils.timestamp_millis(),
-            events_processed_per_sec=self.num_events_processed.calculate_rate(),  # noqa: E501
+            events_processed_per_sec=throughput,  # noqa: E501
             pull_percentage=self._pull_percentage_counter.calculate_rate(),
             process_time_millis=self.process_time_counter.calculate_rate(),
             process_batch_time_millis=self.batch_time_counter.calculate_rate(),
             pull_to_ack_time_millis=self.total_time_counter.calculate_rate(),
+            cpu_percentage=self.cpu_percentage.calculate_rate(),
         )
         # reset the counters
         self._last_snapshot_time = time.monotonic()

--- a/buildflow/core/app/runtime/actors/pipeline_pattern/pull_process_push_test.py
+++ b/buildflow/core/app/runtime/actors/pipeline_pattern/pull_process_push_test.py
@@ -64,6 +64,7 @@ class PullProcessPushTest(unittest.TestCase):
             processor=create_test_processor(
                 self.output_path, [{"field": 1}, {"field": 2}]
             ),
+            replica_id="1",
         )
 
         self.run_with_timeout(actor.run.remote())
@@ -83,7 +84,9 @@ class PullProcessPushTest(unittest.TestCase):
         def process(payload):
             return payload
 
-        actor = PullProcessPushActor.remote(run_id="test-run", processor=process)
+        actor = PullProcessPushActor.remote(
+            run_id="test-run", processor=process, replica_id="1"
+        )
 
         self.run_with_timeout(actor.run.remote())
 
@@ -102,7 +105,9 @@ class PullProcessPushTest(unittest.TestCase):
         async def process(payload):
             return payload
 
-        actor = PullProcessPushActor.remote(run_id="test-run", processor=process)
+        actor = PullProcessPushActor.remote(
+            run_id="test-run", processor=process, replica_id="1"
+        )
 
         self.run_with_timeout(actor.run.remote())
 
@@ -121,7 +126,9 @@ class PullProcessPushTest(unittest.TestCase):
         async def process(payload) -> List[Dict[str, int]]:
             return [payload, payload]
 
-        actor = PullProcessPushActor.remote(run_id="test-run", processor=process)
+        actor = PullProcessPushActor.remote(
+            run_id="test-run", processor=process, replica_id="1"
+        )
 
         self.run_with_timeout(actor.run.remote())
 

--- a/buildflow/core/app/runtime/actors/process_pool.py
+++ b/buildflow/core/app/runtime/actors/process_pool.py
@@ -97,7 +97,9 @@ class ProcessorReplicaPoolActor(Runtime):
 
     async def add_replicas(self, num_replicas: int):
         if self._status != RuntimeStatus.RUNNING:
-            raise RuntimeError("Can only replicas to a processor pool that is running.")
+            raise RuntimeError(
+                "Can only add replicas to a processor pool that is running."
+            )
         for _ in range(num_replicas):
             replica = await self.create_replica()
 

--- a/buildflow/core/app/runtime/actors/process_pool.py
+++ b/buildflow/core/app/runtime/actors/process_pool.py
@@ -17,9 +17,12 @@ from buildflow.core.options.runtime_options import ProcessorOptions
 from buildflow.core.processor.processor import ProcessorAPI, ProcessorID, ProcessorType
 
 
+ReplicaID = str
+
+
 @dataclasses.dataclass
 class ReplicaReference:
-    replica_id: str
+    replica_id: ReplicaID
     ray_actor_handle: ActorHandle
     ray_placement_group: PlacementGroup
 

--- a/buildflow/core/app/runtime/actors/runtime.py
+++ b/buildflow/core/app/runtime/actors/runtime.py
@@ -175,11 +175,10 @@ class RuntimeActor(Runtime):
         ):
             # Only run the autoscale loop when the runtime is running, this prevents
             # us from scaling while we are draining.
-            if (
-                self._status == RuntimeStatus.RUNNING
-                and last_autoscale_event + self._autoscale_frequency > datetime.utcnow()
+            if self._status == RuntimeStatus.RUNNING and (
+                datetime.utcnow() - last_autoscale_event >= self._autoscale_frequency
             ):
-                last_autoscale_event = datetime.now()
+                last_autoscale_event = datetime.utcnow()
                 for processor_pool in self._processor_pool_refs:
                     if self._status != RuntimeStatus.RUNNING:
                         break
@@ -233,5 +232,4 @@ class RuntimeActor(Runtime):
                             abs(num_replicas_delta)
                         )
 
-            # TODO: Add more control / configuration around the checkin loop
             await asyncio.sleep(self.options.checkin_frequency_loop_secs)

--- a/buildflow/core/app/runtime/actors/runtime.py
+++ b/buildflow/core/app/runtime/actors/runtime.py
@@ -71,7 +71,7 @@ class RuntimeActor(Runtime):
     def _set_status(self, status: RuntimeStatus):
         self._status = status
 
-    def run(self, *, processors: Iterable[ProcessorAPI]):
+    async def run(self, *, processors: Iterable[ProcessorAPI]):
         logging.info("Starting Runtime...")
         if self._status != RuntimeStatus.IDLE:
             raise RuntimeError("Can only start an Idle Runtime.")
@@ -106,7 +106,9 @@ class RuntimeActor(Runtime):
             # Ensure we can start the actor. This might fail if the processor is
             # misconfigured.
             processor_pool.actor_handle.run.remote()
-            processor_pool.actor_handle.add_replicas.remote(self.options.num_replicas)
+            await processor_pool.actor_handle.add_replicas.remote(
+                self.options.num_replicas
+            )
 
         self._runtime_loop_future = self._runtime_autoscale_loop()
 
@@ -204,7 +206,7 @@ class RuntimeActor(Runtime):
                         # Restart with the default number of replicas, and let autoscale
                         # handle the rest.
                         processor_pool.actor_handle.run.remote()
-                        processor_pool.actor_handle.add_replicas.remote(
+                        await processor_pool.actor_handle.add_replicas.remote(
                             self.options.num_replicas
                         )
                         continue

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -14,6 +14,7 @@ from buildflow.core.app.flow import Flow
 from buildflow.core.app.runtime.actors.runtime import RuntimeActor
 from buildflow.core.io.local.file import File
 from buildflow.core.io.local.pulse import Pulse
+from buildflow.core.io.local.testing.pulse_with_backlog import PulseWithBacklog
 from buildflow.core.options import ProcessorOptions, RuntimeOptions
 from buildflow.core.types.local_types import FileFormat
 
@@ -27,12 +28,20 @@ class RunTimeTest(unittest.TestCase):
     def tearDown(self) -> None:
         os.remove(self.output_path)
 
-    def run_with_timeout(self, coro):
+    def run_with_timeout(self, coro, timeout: int = 5):
         """Run a coroutine synchronously."""
         try:
-            self.event_loop.run_until_complete(asyncio.wait_for(coro, timeout=5))
+            return self.event_loop.run_until_complete(
+                asyncio.wait_for(coro, timeout=timeout)
+            )
         except asyncio.TimeoutError:
             return
+
+    def run_for_time(self, coro, time: int = 5):
+        async def wait_wrapper():
+            await asyncio.wait([coro], timeout=time)
+
+        self.event_loop.run_until_complete(wait_wrapper())
 
     def assertInStderr(self, expected_match: str):
         _, err = self._capfd.readouterr()
@@ -89,7 +98,7 @@ class RunTimeTest(unittest.TestCase):
 
         runtime_options = RuntimeOptions.default()
         runtime_options.checkin_frequency_loop_secs = 1
-        runtime_options.autoscale_frequency_secs = 1
+        runtime_options.autoscaler_options.autoscale_frequency_secs = 1
         runtime_options.processor_options["process"] = ProcessorOptions.default()
         # NOTE: We need to set the num_cpus to a small value since pytest limits the
         # number of CPUs available to the test process. (I didnt actually verify this
@@ -131,7 +140,7 @@ class RunTimeTest(unittest.TestCase):
         runtime_options = RuntimeOptions.default()
         runtime_options.log_level = "DEBUG"
         runtime_options.checkin_loop_frequency_sec = 1
-        runtime_options.autoscale_frequency_secs = 1
+        runtime_options.autoscaler_options.autoscale_frequency_secs = 1
         runtime_options.processor_options["process"] = ProcessorOptions.default()
         # NOTE: We need to set the num_cpus to a small value since pytest limits the
         # number of CPUs available to the test process. (I didnt actually verify this
@@ -154,10 +163,45 @@ class RunTimeTest(unittest.TestCase):
         pid = pool_actor["pid"]
 
         os.kill(pid, signal.SIGKILL)
-        self.run_with_timeout(actor.run_until_complete.remote())
+        self.run_with_timeout(actor.run_until_complete.remote(), 15)
 
         self.run_with_timeout(actor.drain.remote())
         self.assertInStderr("replica actor unexpectedly died. will restart.")
+
+    def test_runtime_scales_up(self):
+        app = Flow()
+
+        @app.pipeline(
+            source=PulseWithBacklog(
+                [{"field": 1}, {"field": 2}],
+                pulse_interval_seconds=1,
+                # Set an artificial backlog size to force the pipeline to scale up.
+                backlog_size=1000,
+            ),
+            sink=File(file_path=self.output_path, file_format=FileFormat.CSV),
+        )
+        def process(payload):
+            return payload
+
+        runtime_options = RuntimeOptions.default()
+        runtime_options.checkin_loop_frequency_sec = 1
+        runtime_options.autoscaler_options.autoscale_frequency_secs = 1
+        runtime_options.processor_options["process"] = ProcessorOptions.default()
+        # NOTE: We need to set the num_cpus to a small value since pytest limits the
+        # number of CPUs available to the test process. (I didnt actually verify this
+        # but I think its true)
+        runtime_options.processor_options["process"].num_cpus = 0.25
+        actor = RuntimeActor.remote(run_id="test-run", runtime_options=runtime_options)
+
+        self.run_with_timeout(actor.run.remote(processors=[process]))
+
+        self.run_for_time(actor.run_until_complete.remote(), 10)
+
+        snapshot = self.run_with_timeout(actor.snapshot.remote())
+
+        self.run_with_timeout(actor.drain.remote())
+
+        self.assertGreaterEqual(snapshot.processors[0].num_replicas, 2)
 
 
 if __name__ == "__main__":

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -285,7 +285,7 @@ class RunTimeTest(unittest.TestCase):
 
         self.run_with_timeout(actor.run.remote(processors=[process]))
 
-        self.run_for_time(actor.run_until_complete.remote(), 10)
+        self.run_for_time(actor.run_until_complete.remote(), 15)
 
         snapshot = self.run_with_timeout(actor.snapshot.remote())
 

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -251,7 +251,7 @@ class RunTimeTest(unittest.TestCase):
             pid = replica["pid"]
             os.kill(pid, signal.SIGKILL)
 
-        self.run_for_time(pending, 10)
+        self.run_for_time(pending, 5)
         snapshot = self.run_with_timeout(actor.snapshot.remote())
         # Should only have one replica cause we restart with the minumum number.
         self.assertEqual(1, snapshot.processors[0].num_replicas)

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -117,6 +117,7 @@ class RunTimeTest(unittest.TestCase):
             return payload
 
         runtime_options = RuntimeOptions.default()
+        runtime_options.log_level = "DEBUG"
         runtime_options.checkin_loop_frequency_sec = 1
         runtime_options.processor_options["process"] = ProcessorOptions.default()
         # NOTE: We need to set the num_cpus to a small value since pytest limits the

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -251,10 +251,9 @@ class RunTimeTest(unittest.TestCase):
             pid = replica["pid"]
             os.kill(pid, signal.SIGKILL)
 
-        self.run_for_time(pending, 5)
+        self.run_for_time(pending, 10)
         snapshot = self.run_with_timeout(actor.snapshot.remote())
-        # Should only have one replica cause we restart with the minumum number.
-        self.assertEqual(1, snapshot.processors[0].num_replicas)
+        self.assertGreaterEqual(1, snapshot.processors[0].num_replicas)
 
         self.run_with_timeout(actor.drain.remote())
         self.assertInStderr("replica actor unexpectedly died. will restart.")

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -253,7 +253,7 @@ class RunTimeTest(unittest.TestCase):
 
         self.run_for_time(pending, 10)
         snapshot = self.run_with_timeout(actor.snapshot.remote())
-        self.assertGreaterEqual(1, snapshot.processors[0].num_replicas)
+        self.assertGreaterEqual(snapshot.processors[0].num_replicas, 1)
 
         self.run_with_timeout(actor.drain.remote())
         self.assertInStderr("replica actor unexpectedly died. will restart.")

--- a/buildflow/core/app/runtime/actors/runtime_test.py
+++ b/buildflow/core/app/runtime/actors/runtime_test.py
@@ -39,15 +39,20 @@ class RunTimeTest(unittest.TestCase):
 
     def run_for_time(self, coro, time: int = 5):
         async def wait_wrapper():
-            _, pending = await asyncio.wait([coro], timeout=time)
+            completed, pending = await asyncio.wait(
+                [coro], timeout=time, return_when="FIRST_EXCEPTION"
+            )
+            if completed:
+                # This general should only happen when there was an exception so
+                # we want to raise it to make the test failure more obvious.
+                completed.pop().result()
             if pending:
-                return next(iter(pending))
+                return pending.pop()
 
         return self.event_loop.run_until_complete(wait_wrapper())
 
     def assertInStderr(self, expected_match: str):
         _, err = self._capfd.readouterr()
-        print("T: ", err)
         split_err = err.split("\n")
         found_match = False
         for line in split_err:
@@ -145,7 +150,7 @@ class RunTimeTest(unittest.TestCase):
 
         self.assertInStderr("process actor unexpectedly died. will restart.")
 
-    def test_runtime_kill_replica(self):
+    def test_runtime_kill_single_replica(self):
         app = Flow()
 
         @app.pipeline(
@@ -184,8 +189,8 @@ class RunTimeTest(unittest.TestCase):
         snapshot = self.run_with_timeout(actor.snapshot.remote())
         num_replicas = snapshot.processors[0].num_replicas
 
-        # Kill a replica actor.
-        # The let the pipeline run for a couple seconds to allow it to be spun
+        # Kill all replica actors.
+        # Then let the pipeline run for a couple seconds to allow them to be spun
         # up again.
         replica = list_actors(filters=[("class_name", "=", "PullProcessPushActor")])[0]
         pid = replica["pid"]
@@ -194,6 +199,62 @@ class RunTimeTest(unittest.TestCase):
         self.run_for_time(pending, 10)
         snapshot = self.run_with_timeout(actor.snapshot.remote())
         self.assertEqual(num_replicas, snapshot.processors[0].num_replicas)
+
+        self.run_with_timeout(actor.drain.remote())
+        self.assertInStderr("replica actor unexpectedly died. will restart.")
+
+    def test_runtime_kill_all_replicas(self):
+        app = Flow()
+
+        @app.pipeline(
+            source=PulseWithBacklog(
+                [{"field": 1}, {"field": 2}],
+                pulse_interval_seconds=1,
+                # Set an artificial backlog size to force the pipeline to scale up.
+                # We set this to a very large value to ensure we scale up to
+                # out max capacity.
+                backlog_size=1000000,
+            ),
+            sink=File(file_path=self.output_path, file_format=FileFormat.CSV),
+        )
+        def process(payload):
+            return payload
+
+        runtime_options = RuntimeOptions.default()
+        runtime_options.log_level = "DEBUG"
+        runtime_options.checkin_loop_frequency_sec = 1
+        runtime_options.autoscaler_options.autoscale_frequency_secs = 5
+        runtime_options.processor_options["process"] = ProcessorOptions.default()
+        # NOTE: We need to set the num_cpus to a small value since pytest limits the
+        # number of CPUs available to the test process. (I didnt actually verify this
+        # but I think its true)
+        runtime_options.processor_options["process"].num_cpus = 0.25
+        actor = RuntimeActor.remote(
+            run_id="test-run",
+            runtime_options=runtime_options,
+        )
+
+        self.run_with_timeout(actor.run.remote(processors=[process]))
+        # Run for ten seconds to let it scale up.
+        pending = self.run_for_time(actor.run_until_complete.remote(), 10)
+
+        # Grab snapshot to see how many replicas we have scaled up to.
+        snapshot = self.run_with_timeout(actor.snapshot.remote())
+
+        # Kill all replica actors.
+        # Then let the pipeline run for a couple seconds to allow them to be spun
+        # up again.
+        replica_actors = list_actors(
+            filters=[("class_name", "=", "PullProcessPushActor")]
+        )
+        for replica in replica_actors:
+            pid = replica["pid"]
+            os.kill(pid, signal.SIGKILL)
+
+        self.run_for_time(pending, 10)
+        snapshot = self.run_with_timeout(actor.snapshot.remote())
+        # Should only have one replica cause we restart with the minumum number.
+        self.assertEqual(1, snapshot.processors[0].num_replicas)
 
         self.run_with_timeout(actor.drain.remote())
         self.assertInStderr("replica actor unexpectedly died. will restart.")

--- a/buildflow/core/app/runtime/autoscaler.py
+++ b/buildflow/core/app/runtime/autoscaler.py
@@ -152,7 +152,7 @@ def _calculate_target_num_replicas_for_pipeline_v2(
             backlog_growth_per_sec = backlog_growth / (time_gap_ms / 1000)
             want_throughput = throughput + backlog_growth_per_sec
             logging.debug("want throughput: %s", want_throughput)
-        new_num_replicas = math.ceil(want_throughput / throughput_per_replica)
+            new_num_replicas = math.ceil(want_throughput / throughput_per_replica)
     # Scale down event.
     elif (
         avg_replica_cpu_percentage > 0

--- a/buildflow/core/app/runtime/autoscaler.py
+++ b/buildflow/core/app/runtime/autoscaler.py
@@ -182,7 +182,7 @@ def _calculate_target_num_replicas_for_pipeline_v2(
             # Cap how much we request to ensure we're not requesting a huge amount
             cpu_to_request = new_num_replicas * cpus_per_replica * 2
             request_resources(num_cpus=math.ceil(cpu_to_request))
-    elif new_num_replicas < current_snapshot.num_replicas:
+    elif new_num_replicas <= current_snapshot.num_replicas:
         # we're scaling down so only request resources that are needed for
         # the smaller amount.
         # This will override the case where we requested a bunch of

--- a/buildflow/core/app/runtime/autoscaler.py
+++ b/buildflow/core/app/runtime/autoscaler.py
@@ -142,7 +142,7 @@ def _calculate_target_num_replicas_for_pipeline_v2(
         # We do round here to avoid too noisy of scaling.
         # This helps give the current number of replicas a chance to
         # get through the backlog before scaling up.
-        new_num_replicas = int(round(want_throughput / throughput_per_replica))
+        new_num_replicas = math.ceil(want_throughput / throughput_per_replica)
     elif (
         avg_replica_cpu_percentage > 0
         and avg_replica_cpu_percentage < config.pipeline_cpu_percent_target

--- a/buildflow/core/app/runtime/autoscaler.py
+++ b/buildflow/core/app/runtime/autoscaler.py
@@ -1,17 +1,3 @@
-"""Auto-scaler used by the stream manager.
-
-When we do scale up?
-    We check the backlog of the current source, and compare it to the
-    throughput since the last autoscale event we request the number of replicas
-    required to burn down the entire backlog in 60 seconds.
-
-When do we scale down?
-    First we check that we don't need to scale up. If we don't need to scale
-    up, we check what the current utilization of our replicas is above 50%.
-    The utilization is determined by the number of non-empty requests for data
-    were made.
-"""
-
 import logging
 import math
 
@@ -25,49 +11,96 @@ from buildflow.core.app.runtime.actors.process_pool import ProcessorSnapshot
 from buildflow.core.options.runtime_options import AutoscalerOptions
 from buildflow.core.processor.processor import ProcessorType
 
-# TODO: Make this configurable
-_TARGET_UTILIZATION = 0.5
+_BACKLOG_BURN_THRESHOLD = 60
+# We set this a little lower so io bound tasks don't scale down too much.
+_TARGET_CPU_PERCENTAGE = 25
 
 
 def _available_replicas(cpu_per_replica: float):
-    num_cpus = ray.available_resources()["CPU"]
+    num_cpus = ray.available_resources().get("CPU", 0)
 
     return int(num_cpus / cpu_per_replica)
 
 
-def _calculate_target_num_replicas_for_pipeline(
+def _calculate_target_num_replicas_for_pipeline_v2(
     snapshot: PipelineProcessorSnapshot, config: AutoscalerOptions
 ):
-    cpus_per_replica = snapshot.num_cpu_per_replica
-    avg_utilization_score = snapshot.avg_pull_percentage_per_replica
-    total_utilization_score = avg_utilization_score * snapshot.num_replicas
-    # The code below is from the previous version of the autoscaler.
-    # Could probably use another pass through; might be able to simplify
-    # things with the new runtime setup
-    if snapshot.source_backlog is not None and snapshot.avg_num_elements_per_batch != 0:
-        estimated_replicas = int(
-            snapshot.source_backlog / snapshot.avg_num_elements_per_batch
-        )
-    else:
-        estimated_replicas = 0
-    if estimated_replicas > snapshot.num_replicas:
-        new_num_replicas = estimated_replicas
-    elif (
-        estimated_replicas < snapshot.num_replicas
-        and snapshot.num_replicas > 1
-        and avg_utilization_score < _TARGET_UTILIZATION
-    ):
-        # Scale down under the following conditions.
-        # - Backlog is low enough we don't need any more replicas
-        # - We are running more than 1 (don't scale to 0...)
-        # - Over 30% of requests are empty, i.e. we're wasting requests
-        new_num_replicas = math.ceil(total_utilization_score / _TARGET_UTILIZATION)
-        if new_num_replicas < estimated_replicas:
-            new_num_replicas = estimated_replicas
-    else:
-        new_num_replicas = snapshot.num_replicas
+    """The autoscaler used by the pipeline runtime.
 
+    First we check if we need to scale up. If we do not then we check
+    if we should scale down.
+
+    When do we scale up?
+        We check what the current backlog is and how long it would take
+        us to burn down the backlog. If it would take us longer than 60
+        seconds to burn down the backlog with our current throughpu
+        we scale up to the number of replicas that would be required.
+
+        Example:
+            current replicas: 2
+            current throughput: 10 elements/sec
+            backlog: 1000 elements
+
+            In this example it would take us 100 seconds to burn down the
+            entire backlog. Next we calculate what throughput would be need
+            to burn down the backlong in 60 seconds
+                want_throughput =
+                    backlog / 60s
+                    1000 / 60 = 16.6 elements/sec
+
+            Then we calculate how many replicas we would need to achieve that
+            and round that up to get our new number of replicas.
+                new_num_replicas =
+                    want_throughput / (current_throughput / current_replicas)
+                    16.6 / (10 / 2) = ceil(3.3) = 4
+
+    When do we scale down?
+        We scale down by checking the CPU utilization of each replica and target
+        an avergae of 25% utilization. We only check this if we are not scaling up.
+
+        Example:
+            avg_cpu_percentage_per_replica: 5%
+            current_replicas: 3
+
+            new_num_replicas =
+                current_replicas / (25 / avg_cpu_percentage_per_replica)
+                3 / (25 / 5) = ceil(0.6) = 1
+
+    """
+    cpus_per_replica = snapshot.num_cpu_per_replica
+    backlog = snapshot.source_backlog
+    num_replicas = snapshot.num_replicas
+    throughput = snapshot.total_events_processed_per_sec
+    throughput_per_replica = throughput / num_replicas
+    avg_replica_cpu_percentage = snapshot.avg_cpu_percentage_per_replica
     available_replicas = _available_replicas(cpus_per_replica)
+
+    logging.debug("-------------------------AUTOSCALER----------------------\n")
+    logging.debug("config max replicas: %s", config.max_replicas)
+    logging.debug("config min replicas: %s", config.min_replicas)
+    logging.debug("cpus per replica: %s", cpus_per_replica)
+    logging.debug("start num replicas: %s", num_replicas)
+    logging.debug("backlog: %s", backlog)
+    logging.debug("throughput: %s", throughput)
+    logging.debug("throughput per replica: %s", throughput_per_replica)
+    logging.debug("avg replica cpu percentage: %s", avg_replica_cpu_percentage)
+    logging.debug("max available cluster replicas: %s", available_replicas)
+
+    new_num_replicas = num_replicas
+    if throughput > 0 and (backlog / throughput) > _BACKLOG_BURN_THRESHOLD:
+        # Backlog is too high, scale up
+        want_throughput = backlog / _BACKLOG_BURN_THRESHOLD
+        logging.debug("want throughput: %s", want_throughput)
+        new_num_replicas = math.ceil(want_throughput / throughput_per_replica)
+    elif (
+        avg_replica_cpu_percentage > 0
+        and avg_replica_cpu_percentage < _TARGET_CPU_PERCENTAGE
+    ):
+        # Utilization is too low, scale down
+        new_num_replicas = math.ceil(
+            num_replicas / (_TARGET_CPU_PERCENTAGE / avg_replica_cpu_percentage)
+        )
+
     # If we're trying to scale to more than max replicas and max replicas
     # for our cluster is less than our total max replicas
     if new_num_replicas > config.max_replicas:
@@ -96,20 +129,7 @@ def _calculate_target_num_replicas_for_pipeline(
             new_num_replicas,
         )
 
-    logging.debug(
-        "---------------------------------------------------------\n"
-        f"AUTOSCALER: {snapshot.num_replicas} -> {new_num_replicas}\n"
-        f"AVG Utilization: {avg_utilization_score}\n"
-        f"Total Utilization: {total_utilization_score}\n"
-        f"AVG Process Rate: {snapshot.avg_num_elements_per_batch}\n"
-        f"Backlog: {snapshot.source_backlog}\n"
-        f"Estimated Replicas: {estimated_replicas}\n"
-        f"Max Cluster Replicas: {available_replicas}\n"
-        f"Config Max Replicas: {config.max_replicas}\n"
-        f"Config Min Replicas: {config.min_replicas}\n"
-        f"CPUs Per Replicas: {cpus_per_replica}\n"
-        "---------------------------------------------------------\n"
-    )
+    logging.debug("scaling to: %s -> %s", num_replicas, new_num_replicas)
     return new_num_replicas
 
 
@@ -123,7 +143,7 @@ def calculate_target_num_replicas(
     snapshot: ProcessorSnapshot, config: AutoscalerOptions
 ):
     if snapshot.processor_type == ProcessorType.PIPELINE:
-        return _calculate_target_num_replicas_for_pipeline(snapshot, config)
+        return _calculate_target_num_replicas_for_pipeline_v2(snapshot, config)
     elif snapshot.processor_type == ProcessorType.COLLECTOR:
         raise NotImplementedError("Collector autoscaling not implemented yet")
     elif snapshot.processor_type == ProcessorType.CONNECTION:

--- a/buildflow/core/app/runtime/autoscaler_test.py
+++ b/buildflow/core/app/runtime/autoscaler_test.py
@@ -72,10 +72,10 @@ class PipelineAutoScalerTest(unittest.TestCase):
     def test_scale_down_to_estimated_replicas(
         self, request_resources_mock: mock.MagicMock, resources_mock
     ):
-        current_num_replics = 3
+        current_num_replics = 4
         current_throughput = 100000
         backlog = 0
-        avg_cpu_percent = 5
+        avg_cpu_percent = 20
 
         snapshot = create_snapshot(
             num_replicas=current_num_replics,
@@ -93,7 +93,7 @@ class PipelineAutoScalerTest(unittest.TestCase):
             config=config,
         )
         self.assertEqual(rec_replicas, 1)
-        request_resources_mock.assert_called_once_with(num_cpus=1)
+        request_resources_mock.assert_called_once_with(num_cpus=3)
 
     def test_scale_up_to_max_options_replicas(self, resources_mock):
         pass

--- a/buildflow/core/app/runtime/autoscaler_test.py
+++ b/buildflow/core/app/runtime/autoscaler_test.py
@@ -1,0 +1,176 @@
+import logging
+import unittest
+from unittest import mock
+
+import pytest
+
+from buildflow.core.app.runtime import autoscaler
+from buildflow.core.app.runtime._runtime import RuntimeStatus
+from buildflow.core.options.runtime_options import AutoscalerOptions
+from buildflow.core.app.runtime.actors.pipeline_pattern.pipeline_pool import (
+    PipelineProcessorSnapshot,
+)
+from buildflow.core.processor.processor import ProcessorType
+
+
+# Set logging to debug to make test failures easier to groc.
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+def create_snapshot(
+    *,
+    num_replicas: int,
+    throughput: float,
+    backlog: int,
+    num_cpu_per_replica: float = 1,
+    avg_cpu_percent: float = 1,
+) -> PipelineProcessorSnapshot:
+    return PipelineProcessorSnapshot(
+        source_backlog=backlog,
+        total_events_processed_per_sec=throughput,
+        num_replicas=num_replicas,
+        avg_cpu_percentage_per_replica=avg_cpu_percent,
+        num_cpu_per_replica=num_cpu_per_replica,
+        status=RuntimeStatus.RUNNING,
+        timestamp_millis=1,
+        processor_id="id",
+        processor_type=ProcessorType.PIPELINE,
+        num_concurrency_per_replica=1,
+        eta_secs=1,
+        total_pulls_per_sec=1,
+        avg_num_elements_per_batch=1,
+        avg_pull_percentage_per_replica=1,
+        avg_process_time_millis_per_element=1,
+        avg_process_time_millis_per_batch=1,
+        avg_pull_to_ack_time_millis_per_batch=1,
+    )
+
+
+@mock.patch("ray.available_resources", return_value={"CPU": 32})
+class PipelineAutoScalerTest(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def test_scale_up_to_estimated_replicas(self, resources_mock):
+        current_num_replics = 2
+        current_throughput = 10
+        backlog = 1000
+
+        snapshot = create_snapshot(
+            num_replicas=current_num_replics,
+            throughput=current_throughput,
+            backlog=backlog,
+        )
+        config = AutoscalerOptions(
+            enable_autoscaler=True, min_replicas=1, max_replicas=100, log_level="UNUSED"
+        )
+        logging
+        rec_replicas = autoscaler.calculate_target_num_replicas(
+            snapshot,
+            config,
+        )
+        self.assertEqual(rec_replicas, 4)
+
+    @mock.patch("buildflow.core.app.runtime.autoscaler.request_resources")
+    def test_scale_down_to_estimated_replicas(
+        self, request_resources_mock: mock.MagicMock, resources_mock
+    ):
+        current_num_replics = 3
+        current_throughput = 100000
+        backlog = 0
+        avg_cpu_percent = 5
+
+        snapshot = create_snapshot(
+            num_replicas=current_num_replics,
+            throughput=current_throughput,
+            backlog=backlog,
+            avg_cpu_percent=avg_cpu_percent,
+        )
+        config = AutoscalerOptions(
+            enable_autoscaler=True, min_replicas=1, max_replicas=100, log_level="UNUSED"
+        )
+        logging
+        rec_replicas = autoscaler.calculate_target_num_replicas(
+            snapshot,
+            config,
+        )
+        self.assertEqual(rec_replicas, 1)
+        request_resources_mock.assert_called_once_with(num_cpus=1)
+
+    def test_scale_up_to_max_options_replicas(self, resources_mock):
+        pass
+
+    @mock.patch("buildflow.core.app.runtime.autoscaler.request_resources")
+    def test_scale_up_to_max_available_cpu_replicas(
+        self, request_resources_mock: mock.MagicMock, resources_mock
+    ):
+        resources_mock.return_value = {"CPU": 1}
+        current_num_replics = 2
+        current_throughput = 10
+        backlog = 1000
+
+        snapshot = create_snapshot(
+            num_replicas=current_num_replics,
+            throughput=current_throughput,
+            backlog=backlog,
+        )
+        config = AutoscalerOptions(
+            enable_autoscaler=True, min_replicas=1, max_replicas=100, log_level="UNUSED"
+        )
+        logging
+        rec_replicas = autoscaler.calculate_target_num_replicas(
+            snapshot,
+            config,
+        )
+        self.assertEqual(rec_replicas, 3)
+        request_resources_mock.assert_called_once_with(num_cpus=6)
+
+    def test_scale_up_to_max_cpu_replicas_equals_max_options(self, resources_mock):
+        current_num_replics = 2
+        current_throughput = 10
+        backlog = 1000
+
+        snapshot = create_snapshot(
+            num_replicas=current_num_replics,
+            throughput=current_throughput,
+            backlog=backlog,
+        )
+        config = AutoscalerOptions(
+            enable_autoscaler=True, min_replicas=1, max_replicas=3, log_level="UNUSED"
+        )
+        logging
+        rec_replicas = autoscaler.calculate_target_num_replicas(
+            snapshot,
+            config,
+        )
+        self.assertEqual(rec_replicas, 3)
+
+    @mock.patch("buildflow.core.app.runtime.autoscaler.request_resources")
+    def test_scale_down_to_min_options_replicas(
+        self, request_resources_mock: mock.MagicMock, resources_mock
+    ):
+        current_num_replics = 3
+        current_throughput = 100000
+        backlog = 0
+        avg_cpu_percent = 5
+
+        snapshot = create_snapshot(
+            num_replicas=current_num_replics,
+            throughput=current_throughput,
+            backlog=backlog,
+            avg_cpu_percent=avg_cpu_percent,
+        )
+        config = AutoscalerOptions(
+            enable_autoscaler=True, min_replicas=2, max_replicas=100, log_level="UNUSED"
+        )
+        logging
+        rec_replicas = autoscaler.calculate_target_num_replicas(
+            snapshot,
+            config,
+        )
+        self.assertEqual(rec_replicas, 2)
+
+
+if __name__ == "__name__":
+    unittest.main()

--- a/buildflow/core/app/runtime/autoscaler_test.py
+++ b/buildflow/core/app/runtime/autoscaler_test.py
@@ -92,7 +92,7 @@ class PipelineAutoScalerTest(unittest.TestCase):
             prev_snapshot=None,
             config=config,
         )
-        self.assertEqual(rec_replicas, 1)
+        self.assertEqual(rec_replicas, 3)
         request_resources_mock.assert_called_once_with(num_cpus=3)
 
     def test_scale_up_to_max_options_replicas(self, resources_mock):

--- a/buildflow/core/app/runtime/autoscaler_test.py
+++ b/buildflow/core/app/runtime/autoscaler_test.py
@@ -2,8 +2,6 @@ import logging
 import unittest
 from unittest import mock
 
-import pytest
-
 from buildflow.core.app.runtime import autoscaler
 from buildflow.core.app.runtime._runtime import RuntimeStatus
 from buildflow.core.options.runtime_options import AutoscalerOptions
@@ -48,10 +46,6 @@ def create_snapshot(
 
 @mock.patch("ray.available_resources", return_value={"CPU": 32})
 class PipelineAutoScalerTest(unittest.TestCase):
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
-        self._caplog = caplog
-
     def test_scale_up_to_estimated_replicas(self, resources_mock):
         current_num_replics = 2
         current_throughput = 10

--- a/buildflow/core/app/runtime/autoscaler_test.py
+++ b/buildflow/core/app/runtime/autoscaler_test.py
@@ -196,6 +196,7 @@ class PipelineAutoScalerTest(unittest.TestCase):
             throughput=current_throughput,
             backlog=backlog,
             timestamp_millis=current_timestamp,
+            avg_cpu_percent=100,
         )
         config = AutoscalerOptions(
             enable_autoscaler=True, min_replicas=1, max_replicas=100, log_level="UNUSED"

--- a/buildflow/core/app/runtime/server.py
+++ b/buildflow/core/app/runtime/server.py
@@ -45,6 +45,11 @@ index_html = """
 """  # noqa: E501
 
 
+# Set this to avoid noisy logs for alls to each endpoint
+logger = logging.getLogger("ray.serve")
+logger.setLevel("WARNING")
+
+
 @serve.deployment(route_prefix="/", ray_actor_options={"num_cpus": 0.1})
 @serve.ingress(app)
 class RuntimeServer:

--- a/buildflow/core/io/gcp/strategies/pubsub_strategies.py
+++ b/buildflow/core/io/gcp/strategies/pubsub_strategies.py
@@ -108,8 +108,6 @@ class GCPPubSubSubscriptionSource(SourceStrategy):
                     ack_deadline_seconds=ack_deadline_seconds,
                 )
 
-    # TODO: This should not be Optional (goes against Pullable base class)
-    # Should always return an int and handle the case where the backlog is 0
     async def backlog(self) -> int:
         split_sub = self.subscription_id.split("/")
         project = split_sub[1]

--- a/buildflow/core/io/gcp/strategies/pubsub_strategies.py
+++ b/buildflow/core/io/gcp/strategies/pubsub_strategies.py
@@ -139,7 +139,7 @@ class GCPPubSubSubscriptionSource(SourceStrategy):
                 "no autoscaling will happen.",
                 self.subscription_id,
             )
-            return None
+            return -1
         points = list(last_timeseries.points)
         points.sort(
             key=lambda p: _timestamp_to_datetime(p.interval.end_time), reverse=True

--- a/buildflow/core/io/local/providers/pulse_providers.py
+++ b/buildflow/core/io/local/providers/pulse_providers.py
@@ -10,12 +10,14 @@ class PulseProvider(SourceProvider, PulumiProvider):
         *,
         items: Iterable[Any],
         pulse_interval_seconds: float,
+        backlog_size: int = 0,
         # source-only options
         # sink-only options
         # pulumi-only options
     ):
         self.items = items
         self.pulse_interval_seconds = pulse_interval_seconds
+        self.backlog_size = backlog_size
         # sink-only options
         # pulumi-only options
 
@@ -23,6 +25,7 @@ class PulseProvider(SourceProvider, PulumiProvider):
         return PulseSource(
             items=self.items,
             pulse_interval_seconds=self.pulse_interval_seconds,
+            backlog_size=self.backlog_size,
         )
 
     def pulumi_resources(self, type_: Optional[Type]):

--- a/buildflow/core/io/local/strategies/pulse_strategies.py
+++ b/buildflow/core/io/local/strategies/pulse_strategies.py
@@ -6,11 +6,18 @@ from buildflow.core.strategies.source import AckInfo, PullResponse, SourceStrate
 
 
 class PulseSource(SourceStrategy):
-    def __init__(self, *, items: Iterable[Any], pulse_interval_seconds: float):
+    def __init__(
+        self,
+        *,
+        items: Iterable[Any],
+        pulse_interval_seconds: float,
+        backlog_size: int = 0,
+    ):
         super().__init__(strategy_id="local-pulse-source")
         self.items = items
         self.pulse_interval_seconds = pulse_interval_seconds
         self._to_emit = 0
+        self.backlog_size = backlog_size
 
     def max_batch_size(self) -> int:
         return 1
@@ -30,4 +37,4 @@ class PulseSource(SourceStrategy):
         pass
 
     async def backlog(self) -> int:
-        return 0
+        return self.backlog_size

--- a/buildflow/core/io/local/testing/README.md
+++ b/buildflow/core/io/local/testing/README.md
@@ -1,0 +1,4 @@
+# Testing IO
+
+These IO implementations are inteded for testing purposes only. They are not
+intended for production use.

--- a/buildflow/core/io/local/testing/pulse_with_backlog.py
+++ b/buildflow/core/io/local/testing/pulse_with_backlog.py
@@ -1,0 +1,42 @@
+import dataclasses
+from typing import Any, Iterable
+
+from buildflow.config.cloud_provider_config import LocalOptions
+from buildflow.core.io.local.providers.pulse_providers import PulseProvider
+from buildflow.core.io.primitive import LocalPrimtive
+
+
+@dataclasses.dataclass
+class PulseWithBacklog(LocalPrimtive):
+    items: Iterable[Any]
+    pulse_interval_seconds: float
+    backlog_size: int
+
+    @classmethod
+    def from_local_options(
+        cls,
+        local_options: LocalOptions,
+        *,
+        items: Iterable[Any],
+        pulse_interval_seconds: float,
+        backlog_size: int,
+    ) -> "PulseWithBacklog":
+        return cls(
+            items=items,
+            pulse_interval_seconds=pulse_interval_seconds,
+            backlog_size=backlog_size,
+        )
+
+    def source_provider(self) -> PulseProvider:
+        return PulseProvider(
+            items=self.items,
+            pulse_interval_seconds=self.pulse_interval_seconds,
+            backlog_size=self.backlog_size,
+        )
+
+    def pulumi_provider(self) -> PulseProvider:
+        return PulseProvider(
+            items=self.items,
+            pulse_interval_seconds=self.pulse_interval_seconds,
+            backlog_size=self.backlog_size,
+        )

--- a/buildflow/core/options/flow_options.py
+++ b/buildflow/core/options/flow_options.py
@@ -1,18 +1,67 @@
 import dataclasses
 
 from buildflow.core.options._options import Options
-from buildflow.core.options.infra_options import InfraOptions
-from buildflow.core.options.runtime_options import RuntimeOptions
+from buildflow.core.options.infra_options import InfraOptions, PulumiOptions
+from buildflow.core.options.runtime_options import AutoscalerOptions, RuntimeOptions
 
 
 @dataclasses.dataclass
 class FlowOptions(Options):
-    runtime_options: RuntimeOptions
-    infra_options: InfraOptions
+    # Runtime options:
+    #   The number of replicas to start with
+    num_replicas: int = 1
+    #   Log level for runtime
+    runtime_log_level: str = "INFO"
+    #   Whether or not autoscaling shoule be enabled.
+    enable_autoscaler: bool = True
+    #   Minimum number of replicas to scale down to.
+    min_replicas: int = 1
+    #   Maximum number of replicas to scale up to.
+    max_replicas: int = 1000
+    # Infra options
+    #   Whether schema validation should be enabled.
+    #   Valid values are: strict, warning, none
+    schema_validation: str = "none"
+    #   Whether or not confirmation should be required before applying changes.
+    require_confirmation: bool = True
+    #   Whether destroy projection should be enabled for pulumi.
+    enable_destroy_protection: bool = False
+    #   Whether or not to refresh state before applying changes.
+    refresh_state: bool = True
+    #   Log level for infra
+    infra_log_level: str = "INFO"
+
+    def __post_init__(self):
+        self._runtime_options = RuntimeOptions(
+            processor_options={},
+            num_replicas=self.num_replicas,
+            log_level=self.runtime_log_level,
+            autoscaler_options=AutoscalerOptions(
+                enable_autoscaler=self.enable_autoscaler,
+                min_replicas=self.min_replicas,
+                max_replicas=self.max_replicas,
+                log_level=self.runtime_log_level,
+            ),
+        )
+        self._infra_options = InfraOptions(
+            pulumi_options=PulumiOptions(
+                enable_destroy_protection=self.enable_destroy_protection,
+                refresh_state=self.refresh_state,
+                log_level=self.infra_log_level,
+            ),
+            schema_validation=self.schema_validation,
+            require_confirmation=self.require_confirmation,
+            log_level=self.infra_log_level,
+        )
+
+    @property
+    def runtime_options(self) -> RuntimeOptions:
+        return self._runtime_options
+
+    @property
+    def infra_options(self) -> InfraOptions:
+        return self._infra_options
 
     @classmethod
-    def default(cls) -> "FlowOptions":
-        return cls(
-            runtime_options=RuntimeOptions.default(),
-            infra_options=InfraOptions.default(),
-        )
+    def default(cls) -> Options:
+        return FlowOptions()

--- a/buildflow/core/options/flow_options.py
+++ b/buildflow/core/options/flow_options.py
@@ -18,6 +18,14 @@ class FlowOptions(Options):
     min_replicas: int = 1
     #   Maximum number of replicas to scale up to.
     max_replicas: int = 1000
+    #   The threshold for how long it will take to burn down a
+    #   backlog before scaleing up. Increasing this number
+    #   will cause your pipeline to scale up more aggresively.
+    pipeline_backlog_burn_threshold: int = 60
+    #   The target cpu percentage for scaling down. Increasing
+    #   this number will cause your pipeline to scale down more
+    #   aggresively.
+    pipeline_cpu_percent_target: int = 25
     # Infra options
     #   Whether schema validation should be enabled.
     #   Valid values are: strict, warning, none
@@ -41,6 +49,8 @@ class FlowOptions(Options):
                 min_replicas=self.min_replicas,
                 max_replicas=self.max_replicas,
                 log_level=self.runtime_log_level,
+                pipeline_backlog_burn_threshold=self.pipeline_backlog_burn_threshold,
+                pipeline_cpu_percent_target=self.pipeline_cpu_percent_target,
             ),
         )
         self._infra_options = InfraOptions(

--- a/buildflow/core/options/flow_options.py
+++ b/buildflow/core/options/flow_options.py
@@ -1,46 +1,70 @@
-import dataclasses
-
 from buildflow.core.options._options import Options
 from buildflow.core.options.infra_options import InfraOptions, PulumiOptions
 from buildflow.core.options.runtime_options import AutoscalerOptions, RuntimeOptions
 
 
-@dataclasses.dataclass
 class FlowOptions(Options):
-    # Runtime options:
-    #   The number of replicas to start with
-    num_replicas: int = 1
-    #   Log level for runtime
-    runtime_log_level: str = "INFO"
-    #   Whether or not autoscaling shoule be enabled.
-    enable_autoscaler: bool = True
-    #   Minimum number of replicas to scale down to.
-    min_replicas: int = 1
-    #   Maximum number of replicas to scale up to.
-    max_replicas: int = 1000
-    #   The threshold for how long it will take to burn down a
-    #   backlog before scaleing up. Increasing this number
-    #   will cause your pipeline to scale up more aggresively.
-    pipeline_backlog_burn_threshold: int = 60
-    #   The target cpu percentage for scaling down. Increasing
-    #   this number will cause your pipeline to scale down more
-    #   aggresively.
-    pipeline_cpu_percent_target: int = 25
-    # Infra options
-    #   Whether schema validation should be enabled.
-    #   Valid values are: strict, warning, none
-    schema_validation: str = "none"
-    #   Whether or not confirmation should be required before applying changes.
-    require_confirmation: bool = True
-    #   Whether destroy projection should be enabled for pulumi.
-    enable_destroy_protection: bool = False
-    #   Whether or not to refresh state before applying changes.
-    refresh_state: bool = True
-    #   Log level for infra
-    infra_log_level: str = "INFO"
+    def __init__(
+        self,
+        *,
+        # Runtime options
+        num_replicas: int = 1,
+        runtime_log_level: str = "INFO",
+        # Autoscaler options
+        enable_autoscaler: bool = True,
+        min_replicas: int = 1,
+        max_replicas: int = 1000,
+        pipeline_backlog_burn_threshold: int = 60,
+        pipeline_cpu_percent_target: int = 25,
+        # Infra options
+        schema_validation: str = "none",
+        require_confirmation: bool = True,
+        infra_log_level: str = "INFO",
+        # Pulumi options
+        enable_destroy_protection: bool = False,
+        refresh_state: bool = True,
+    ) -> None:
+        """Options for configuring a Flow.
 
-    def __post_init__(self):
-        self._runtime_options = RuntimeOptions(
+        Args:
+            num_replicas (int): The number of replicas to start with. Defaults to 1.
+            runtime_log_level (str): The log level for the runtime. Defaults to "INFO".
+            enable_autoscaler (bool): Whether or not autoscaling should be enabled.
+                Defaults to True.
+            min_replicas (int): The minimum number of replicas to scale down to.
+                Defaults to 1.
+            max_replicas (int): The maximum number of replicas to scale up to.
+                Defaults to 1000.
+            pipeline_backlog_burn_threshold (int): The threshold for how long it will
+                take to burn down a backlog before scaling up. Increasing this number
+                will cause your pipeline to scale up more aggresively. Defaults to 60.
+            pipeline_cpu_percent_target (int): The target cpu percentage for scaling
+                down. Increasing this number will cause your pipeline to scale down
+                more aggresively. Defaults to 25.
+            schema_validation (str): Whether schema validation should be enabled.
+                Valid values are: strict, warning, none. Defaults to "none".
+            require_confirmation (bool): Whether or not confirmation should be
+                required before applying changes. Defaults to True.
+            infra_log_level (str): The log level for the infra. Defaults to "INFO".
+            enable_destroy_protection (bool): Whether destroy projection should be
+                enabled for pulumi. Defaults to False.
+            refresh_state (bool): Whether or not to refresh state before applying
+                changes. Defaults to True.
+        """
+        super().__init__()
+        self.num_replicas = num_replicas
+        self.runtime_log_level = runtime_log_level
+        self.enable_autoscaler = enable_autoscaler
+        self.min_replicas = min_replicas
+        self.max_replicas = max_replicas
+        self.pipeline_backlog_burn_threshold = pipeline_backlog_burn_threshold
+        self.pipeline_cpu_percent_target = pipeline_cpu_percent_target
+        self.schema_validation = schema_validation
+        self.require_confirmation = require_confirmation
+        self.infra_log_level = infra_log_level
+        self.enable_destroy_protection = enable_destroy_protection
+        self.refresh_state = refresh_state
+        self.runtime_options = RuntimeOptions(
             processor_options={},
             num_replicas=self.num_replicas,
             log_level=self.runtime_log_level,
@@ -53,7 +77,7 @@ class FlowOptions(Options):
                 pipeline_cpu_percent_target=self.pipeline_cpu_percent_target,
             ),
         )
-        self._infra_options = InfraOptions(
+        self.infra_options = InfraOptions(
             pulumi_options=PulumiOptions(
                 enable_destroy_protection=self.enable_destroy_protection,
                 refresh_state=self.refresh_state,
@@ -63,14 +87,6 @@ class FlowOptions(Options):
             require_confirmation=self.require_confirmation,
             log_level=self.infra_log_level,
         )
-
-    @property
-    def runtime_options(self) -> RuntimeOptions:
-        return self._runtime_options
-
-    @property
-    def infra_options(self) -> InfraOptions:
-        return self._infra_options
 
     @classmethod
     def default(cls) -> Options:

--- a/buildflow/core/options/runtime_options.py
+++ b/buildflow/core/options/runtime_options.py
@@ -40,6 +40,13 @@ class AutoscalerOptions(Options):
             log_level="INFO",
         )
 
+    def __post_init__(self):
+        if (
+            self.pipeline_cpu_percent_target < 0
+            or self.pipeline_cpu_percent_target > 100
+        ):
+            raise ValueError("pipeline_cpu_percent_target must be between 0 and 100")
+
 
 @dataclasses.dataclass
 class RuntimeOptions(Options):

--- a/buildflow/core/options/runtime_options.py
+++ b/buildflow/core/options/runtime_options.py
@@ -48,7 +48,8 @@ class RuntimeOptions(Options):
     num_replicas: int
     # misc
     log_level: str
-    checkin_frequency_loop_secs: int = 5
+    # we set this to a higher value to avoid noisy scaling up/down too often
+    checkin_frequency_loop_secs: int = 60
 
     @classmethod
     def default(cls) -> "RuntimeOptions":

--- a/buildflow/core/options/runtime_options.py
+++ b/buildflow/core/options/runtime_options.py
@@ -48,8 +48,8 @@ class RuntimeOptions(Options):
     num_replicas: int
     # misc
     log_level: str
-    # we set this to a higher value to avoid noisy scaling up/down too often
-    checkin_frequency_loop_secs: int = 60
+    checkin_frequency_loop_secs: int = 5
+    autoscale_frequency_secs: int = 60
 
     @classmethod
     def default(cls) -> "RuntimeOptions":

--- a/buildflow/core/options/runtime_options.py
+++ b/buildflow/core/options/runtime_options.py
@@ -27,6 +27,9 @@ class AutoscalerOptions(Options):
     min_replicas: int
     max_replicas: int
     log_level: str
+    autoscale_frequency_secs: int = 60
+    pipeline_backlog_burn_threshold: int = 60
+    pipeline_cpu_percent_target: int = 25
 
     @classmethod
     def default(cls) -> "AutoscalerOptions":
@@ -49,7 +52,6 @@ class RuntimeOptions(Options):
     # misc
     log_level: str
     checkin_frequency_loop_secs: int = 5
-    autoscale_frequency_secs: int = 60
 
     @classmethod
     def default(cls) -> "RuntimeOptions":


### PR DESCRIPTION
couple other small fixes in here:
- flatten runtime / infra options in flow options. This effectively made the internal options private.
- fixed the noisy logs from the runtime server
- change so we only scale once per minute and only check the status every 5 minutes