### PR TITLE
remove restrictions on pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pulumi_snowflake",
     "pyarrow",
     "pydantic<2.0.2",
-    "pyyaml",
+    "pyyaml!=6.0.0",
     "s3fs",
     "sqlalchemy[asyncio]",
     "snowflake-ingest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,13 @@ dependencies = [
     # We can remove this once duckdb has released version 0.8.2
     "pandas",
     "pg8000",
-    "pulumi==3.35.3",
+    "pulumi==3.98.0",
     "pulumi_aws",
     "pulumi_gcp",
     "pulumi_snowflake",
     "pyarrow",
     "pydantic<2.0.2",
+    # Add constraints to ensure pyyaml works with cython 3.
     "pyyaml!=5.4.0,!=6.0.0,!=5.4.1",
     "s3fs",
     "sqlalchemy[asyncio]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "buildflow"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name = "Caleb Van Dyke", email = "caleb@launchflow.com" },
     { name = "Josh Tanke", email = "josh@launchflow.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ dependencies = [
     "pulumi_snowflake",
     "pyarrow",
     "pydantic<2.0.2",
-    # Avoid issue with cython 3.0.0 and pyyaml:
-    #   https://github.com/yaml/pyyaml/issues/724
-    "pyyaml<5.4.0,<6.0.0",
+    "pyyaml",
     "s3fs",
     "sqlalchemy[asyncio]",
     "snowflake-ingest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pulumi_snowflake",
     "pyarrow",
     "pydantic<2.0.2",
-    "pyyaml!=6.0.0",
+    "pyyaml<5.4.0,>6.0.0",
     "s3fs",
     "sqlalchemy[asyncio]",
     "snowflake-ingest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pulumi_snowflake",
     "pyarrow",
     "pydantic<2.0.2",
-    "pyyaml<5.4.0,>6.0.0",
+    "pyyaml!=5.4.0,!=6.0.0,!=5.4.1",
     "s3fs",
     "sqlalchemy[asyncio]",
     "snowflake-ingest",


### PR DESCRIPTION
I also had to bump the version of pulumi that we require. The main motivation for this is because pyyaml versions < 5.4 have a vulnerability 